### PR TITLE
Use absolute path to reference ssh key.

### DIFF
--- a/travis/compile_all.sh
+++ b/travis/compile_all.sh
@@ -4,7 +4,7 @@ set -e
 
 BASE_DIR="BUILD_${PLATFORM}"
 NIGHTLY_ARCHIVES_DIR=${HOME}/NIGHTLY_ARCHIVES
-SSH_KEY=travis/travisci_builder_id_key
+SSH_KEY=${TRAVIS_BUILD_DIR}/travis/travisci_builder_id_key
 
 mkdir -p ${NIGHTLY_ARCHIVES_DIR}
 


### PR DESCRIPTION
Relative path is a bad idea, it fails if we change the current directory.
(And it actually fails with the scp)