### PR TITLE
Install ctpp2-utils to have ctpp2 compiler installed.

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -143,10 +143,32 @@ class CTPP2(Dependency):
                    "ctpp2_mingw32.patch",
                    "ctpp2_dll_export_VMExecutable.patch",
                    "ctpp2_win_install_lib_in_lib_dir.patch",
-                   "ctpp2_iconv_support.patch"]
+                   "ctpp2_iconv_support.patch",
+                   "ctpp2_compile_ctpp2c_static.patch",
+                  ]
 
     class Builder(CMakeBuilder):
         configure_option = "-DMD5_SUPPORT=OFF"
+
+
+class CTPP2C(CTPP2):
+    name = "ctpp2c"
+    force_native_build = True
+
+    class Builder(CTPP2.Builder):
+        make_target = "ctpp2c"
+
+        @property
+        def build_path(self):
+            return super().build_path+"_native"
+
+        def _install(self, context):
+            context.try_skip(self.build_path)
+            command = "cp {ctpp2c}* {install_dir}".format(
+                ctpp2c=pj(self.build_path, 'ctpp2c'),
+                install_dir=pj(self.buildEnv.install_dir, 'bin')
+            )
+            self.buildEnv.run_command(command, self.build_path, context)
 
 
 class Pugixml(Dependency):
@@ -272,7 +294,7 @@ class Kiwixlib(Dependency):
     def dependencies(self):
         base_dependencies = ["pugixml", "libzim", "zlib", "lzma"]
         if self.buildEnv.platform_info.build != 'android':
-            base_dependencies += ['ctpp2']
+            base_dependencies += ['ctpp2', 'ctpp2c']
         if self.buildEnv.platform_info.build != 'native':
             return base_dependencies + ["icu4c_cross-compile"]
         else:

--- a/dependency_utils.py
+++ b/dependency_utils.py
@@ -274,6 +274,9 @@ class MakeBuilder(Builder):
 class CMakeBuilder(MakeBuilder):
     def _configure(self, context):
         context.try_skip(self.build_path)
+        cross_option = ""
+        if not self.target.force_native_build and self.buildEnv.cmake_crossfile:
+            cross_option = "-DCMAKE_TOOLCHAIN_FILE={}".format(self.buildEnv.cmake_crossfile)
         command = ("cmake {configure_option}"
                    " -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
                    " -DCMAKE_INSTALL_PREFIX={install_dir}"
@@ -285,7 +288,7 @@ class CMakeBuilder(MakeBuilder):
             install_dir=self.buildEnv.install_dir,
             libdir=self.buildEnv.libprefix,
             source_path=self.source_path,
-            cross_option="-DCMAKE_TOOLCHAIN_FILE={}".format(self.buildEnv.cmake_crossfile) if self.buildEnv.cmake_crossfile else ""
+            cross_option=cross_option
         )
         env = Defaultdict(str, os.environ)
         if self.buildEnv.platform_info.static:
@@ -313,6 +316,10 @@ class MesonBuilder(Builder):
             shutil.rmtree(self.build_path)
         os.makedirs(self.build_path)
         configure_option = self.configure_option.format(buildEnv=self.buildEnv)
+        cross_option = ""
+        if not self.target.force_native_build and self.buildEnv.meson_crossfile:
+            cross_option = "--cross-file {}".format(
+                self.buildEnv.meson_crossfile)
         command = ("{command} . {build_path}"
                    " --default-library={library_type}"
                    " {configure_option}"
@@ -325,7 +332,7 @@ class MesonBuilder(Builder):
             configure_option=configure_option,
             build_path=self.build_path,
             buildEnv=self.buildEnv,
-            cross_option="--cross-file {}".format(self.buildEnv.meson_crossfile) if self.buildEnv.meson_crossfile else ""
+            cross_option=cross_option
         )
         self.buildEnv.run_command(command, self.source_path, context, cross_env_only=True)
 

--- a/kiwix-build.py
+++ b/kiwix-build.py
@@ -79,6 +79,7 @@ PACKAGE_NAME_MAPPERS = {
         'zlib': ['zlib1g-dev'],
         'uuid': ['uuid-dev'],
         'ctpp2': ['libctpp2-dev'],
+        'ctpp2c': ['ctpp2-utils'],
         'libmicrohttpd': ['libmicrohttpd-dev', 'ccache']
     },
     'debian_native_static': {
@@ -86,21 +87,27 @@ PACKAGE_NAME_MAPPERS = {
         'zlib': ['zlib1g-dev'],
         'uuid': ['uuid-dev'],
         'ctpp2': ['libctpp2-dev'],
+        'ctpp2c': ['ctpp2-utils'],
     },
     'debian_win32_dyn': {
-        'COMMON': _debian_common + ['g++-mingw-w64-i686', 'gcc-mingw-w64-i686', 'gcc-mingw-w64-base', 'mingw-w64-tools']
+        'COMMON': _debian_common + ['g++-mingw-w64-i686', 'gcc-mingw-w64-i686', 'gcc-mingw-w64-base', 'mingw-w64-tools'],
+        'ctpp2c': ['ctpp2-utils'],
     },
     'debian_win32_static': {
-        'COMMON': _debian_common + ['g++-mingw-w64-i686', 'gcc-mingw-w64-i686', 'gcc-mingw-w64-base', 'mingw-w64-tools']
+        'COMMON': _debian_common + ['g++-mingw-w64-i686', 'gcc-mingw-w64-i686', 'gcc-mingw-w64-base', 'mingw-w64-tools'],
+        'ctpp2c': ['ctpp2-utils'],
     },
     'debian_armhf_static': {
-        'COMMON': _debian_common
+        'COMMON': _debian_common,
+        'ctpp2c': ['ctpp2-utils'],
     },
     'debian_armhf_dyn': {
-        'COMMON': _debian_common
+        'COMMON': _debian_common,
+        'ctpp2c': ['ctpp2-utils'],
     },
     'debian_android': {
-        'COMMON': _debian_common + ['default-jdk']
+        'COMMON': _debian_common + ['default-jdk'],
+        'ctpp2c': ['ctpp2-utils'],
     },
 }
 

--- a/patches/ctpp2_compile_ctpp2c_static.patch
+++ b/patches/ctpp2_compile_ctpp2c_static.patch
@@ -1,0 +1,13 @@
+diff -u ctpp2-2.8.3/CMakeLists.txt ctpp2-2.8.3-static/CMakeLists.txt
+--- ctpp2-2.8.3/CMakeLists.txt	2017-07-12 11:53:28.656535071 +0200
++++ ctpp2-2.8.3-static/CMakeLists.txt	2017-07-12 11:52:15.358692988 +0200
+@@ -464,7 +464,8 @@
+ 
+ # CTPP Compiler
+ ADD_EXECUTABLE(ctpp2c                       tests/CTPP2Compiler.cpp)
+-TARGET_LINK_LIBRARIES(ctpp2c                ctpp2)
++TARGET_LINK_LIBRARIES(ctpp2c                ctpp2-static)
++TARGET_LINK_LIBRARIES(ctpp2c                "-static")
+ 
+ # CTPP2 Interpreter
+ ADD_EXECUTABLE(ctpp2i                       tests/CTPP2Interpreter.cpp)


### PR DESCRIPTION
Now that kiwix-lib compile ctpp2 template, we also need ctpp2c binary.