### PR TITLE
[CTPP2] CMake should not install ctpp2c.

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -292,9 +292,9 @@ class Kiwixlib(Dependency):
 
     @property
     def dependencies(self):
-        base_dependencies = ["pugixml", "libzim", "zlib", "lzma"]
+        base_dependencies = ["pugixml", "libzim", "zlib", "lzma", "ctpp2c"]
         if self.buildEnv.platform_info.build != 'android':
-            base_dependencies += ['ctpp2', 'ctpp2c']
+            base_dependencies += ['ctpp2']
         if self.buildEnv.platform_info.build != 'native':
             return base_dependencies + ["icu4c_cross-compile"]
         else:

--- a/patches/ctpp2_compile_ctpp2c_static.patch
+++ b/patches/ctpp2_compile_ctpp2c_static.patch
@@ -11,3 +11,27 @@ diff -u ctpp2-2.8.3/CMakeLists.txt ctpp2-2.8.3-static/CMakeLists.txt
  
  # CTPP2 Interpreter
  ADD_EXECUTABLE(ctpp2i                       tests/CTPP2Interpreter.cpp)
+@@ -794,7 +795,6 @@
+             DESTINATION .)
+ 
+     INSTALL(TARGETS ctpp2vm
+-                    ctpp2c
+                     ctpp2i
+                     ctpp2json
+             DESTINATION .)
+@@ -806,7 +806,6 @@
+ # Install Manpages
+ INSTALL(FILES
+               man/ctpp2-config.1
+-              man/ctpp2c.1
+               man/ctpp2i.1
+               man/ctpp2json.1
+               man/ctpp2vm.1
+@@ -904,7 +903,6 @@
+ 
+     # Install binaries
+     INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/ctpp2vm
+-                  ${CMAKE_CURRENT_BINARY_DIR}/ctpp2c
+                   ${CMAKE_CURRENT_BINARY_DIR}/ctpp2i
+                   ${CMAKE_CURRENT_BINARY_DIR}/ctpp2json
+                   ${CMAKE_CURRENT_BINARY_DIR}/ctpp2-config


### PR DESCRIPTION
As we are compiling `ctpp2c` in static native and install it with a simple
`cp`, the default compilation of ctpp2 library should not install ctpp2c.

Else we would have a wrong `ctpp2c` in the path and later compilation will
fail.