### PR TITLE
Fix installation of meson and pillow (pip3) in travis.

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -377,7 +377,7 @@ class KiwixAndroid(Dependency):
 
         def _configure(self, context):
             if not os.path.exists(self.build_path):
-                shutil.copytree(self.source_path, self.build_path)
+                shutil.copytree(self.source_path, self.build_path, symlinks=True)
             try:
                 shutil.rmtree(pj(self.build_path, 'kiwixlib', 'src', 'main'))
             except FileNotFoundError:

--- a/travis/install_extra_deps.sh
+++ b/travis/install_extra_deps.sh
@@ -6,8 +6,8 @@ orig_dir=$(pwd)
 
 sudo apt-get update -qq
 sudo apt-get install -qq python3-pip zlib1g-dev libjpeg-dev
-pip3 install meson
-pip3 install pillow
+pip3 install --user meson
+pip3 install --user pillow
 
 # ninja
 git clone git://github.com/ninja-build/ninja.git


### PR DESCRIPTION
I don't know why, but the travis build doesn't work since few days.
It seems that pip3 cannot install in `/usr/local` anymore.
Probably related to last travis change* as a lot of people seems to have
problem with this update and python (even if this is not the same problems)

Anyway, we should not install a dependencies in global environment without
a sudo. Let's install the pip3 dependencies for the user only.

[*] https://docs.travis-ci.com/user/build-environment-updates/2017-09-06/