### PR TITLE
Run meson test when possible.

### DIFF
--- a/dependency_utils.py
+++ b/dependency_utils.py
@@ -210,6 +210,8 @@ class Builder:
             self.command('pre_build_script', self._pre_build_script)
         self.command('configure', self._configure)
         self.command('compile', self._compile)
+        if hasattr(self, '_test'):
+            self.command('test', self._test)
         self.command('install', self._install)
         if hasattr(self, '_post_build_script'):
             self.command('post_build_script', self._post_build_script)
@@ -338,6 +340,15 @@ class MesonBuilder(Builder):
 
     def _compile(self, context):
         command = "{} -v".format(self.buildEnv.ninja_command)
+        self.buildEnv.run_command(command, self.build_path, context)
+
+    def _test(self, context):
+        if ( self.buildEnv.platform_info.build == 'android'
+             or (self.buildEnv.platform_info.build != 'native'
+                 and not self.buildEnv.platform_info.static)
+           ):
+            raise SkipCommand()
+        command = "{} --verbose".format(self.buildEnv.mesontest_command)
         self.buildEnv.run_command(command, self.build_path, context)
 
     def _install(self, context):

--- a/templates/meson_android_cross_file.txt
+++ b/templates/meson_android_cross_file.txt
@@ -4,7 +4,6 @@ c = '{toolchain.binaries[CC]}'
 ar = '{toolchain.binaries[AR]}'
 cpp = '{toolchain.binaries[CXX]}'
 strip = '{toolchain.binaries[STRIP]}'
-{toolchain.exec_wrapper_def}
 
 [properties]
 c_link_args = {extra_libs!r}


### PR DESCRIPTION
To run unit-test (meson) on cross-compilation, we need a wrapper to run
the binary (wine, qemu, ...), but:

- We have no emulator for android (we have one for the system, but we can't
  simply run a binary)
- With dynamic compilation, it seems pretty complex to configure them
  correctly.
- For mingw32 compilation, `wine` need to be correctly configured to
  find dll from the system mingw32 installation.