### PR TITLE
Avoid rename the meson cross compilation file.

### DIFF
--- a/kiwix-build.py
+++ b/kiwix-build.py
@@ -329,7 +329,7 @@ class BuildEnv:
 
     def setup_android(self):
         self.cmake_crossfile = self._gen_crossfile('cmake_android_cross_file.txt')
-        self.meson_crossfile = self._gen_crossfile('meson_android_cross_file.txt')
+        self.meson_crossfile = self._gen_crossfile('meson_cross_file.txt')
 
     def setup_armhf(self):
         self.cmake_crossfile = self._gen_crossfile('cmake_cross_file.txt')


### PR DESCRIPTION
This file is exported in CI archive for other projects.
If we change its name, it will not be exported and other projects will
break.