### PR TITLE
Stop using the deprecated (and broken) `mesontest`.

### DIFF
--- a/kiwix-build.py
+++ b/kiwix-build.py
@@ -254,7 +254,7 @@ class BuildEnv:
         self.meson_command = self._detect_meson()
         if not self.meson_command:
             sys.exit("ERROR: meson command not fount")
-        self.mesontest_command = "mesontest"
+        self.mesontest_command = "meson test"
         self.setup_build(options.target_platform)
         self.setup_toolchains()
         self.options = options

--- a/travis/install_extra_deps.sh
+++ b/travis/install_extra_deps.sh
@@ -6,7 +6,7 @@ orig_dir=$(pwd)
 
 sudo apt-get update -qq
 sudo apt-get install -qq python3-pip zlib1g-dev libjpeg-dev
-pip3 install --user meson
+pip3 install --user meson==0.43.0
 pip3 install --user pillow
 
 # ninja


### PR DESCRIPTION
`mesontest` command is deprecated since meson 0.42.0 and broken with last
release (0.44.0) (see mesonbuild/meson#2761).

Fix #97.