### PR TITLE
Update to last version of icu4c.

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -217,11 +217,11 @@ class Gumbo(Dependency):
 
 class Icu(Dependency):
     name = "icu4c"
-    version = "58.2"
+    version = "60.1"
 
     class Source(SvnClone):
         name = "icu4c"
-        svn_remote = "http://source.icu-project.org/repos/icu/tags/release-58-2/icu4c"
+        svn_remote = "http://source.icu-project.org/repos/icu/tags/release-60-1/icu4c"
         svn_dir = "icu4c"
 
         patches = ["icu4c_fix_static_lib_name_mingw.patch",
@@ -424,10 +424,10 @@ class KiwixAndroid(Dependency):
             os.makedirs(
                 pj(self.build_path, 'app', 'src', 'main', 'assets', 'icu'),
                 exist_ok=True)
-            shutil.copy2(pj(self.buildEnv.install_dir, 'share', 'icu', '58.2',
-                            'icudt58l.dat'),
+            shutil.copy2(pj(self.buildEnv.install_dir, 'share', 'icu', '60.1',
+                            'icudt60l.dat'),
                          pj(self.build_path, 'app', 'src', 'main', 'assets',
-                            'icu', 'icudt58l.dat'))
+                            'icu', 'icudt60l.dat'))
 
 
 class KiwixCustomApp(Dependency):
@@ -513,10 +513,10 @@ class KiwixCustomApp(Dependency):
             os.makedirs(
                 pj(self.build_path, 'app', 'src', 'main', 'assets', 'icu'),
                 exist_ok=True)
-            shutil.copy2(pj(self.buildEnv.install_dir, 'share', 'icu', '58.2',
-                            'icudt58l.dat'),
+            shutil.copy2(pj(self.buildEnv.install_dir, 'share', 'icu', '60.1',
+                            'icudt60l.dat'),
                          pj(self.build_path, 'app', 'src', 'main', 'assets',
-                            'icu', 'icudt58l.dat'))
+                            'icu', 'icudt60l.dat'))
 
             # Generate custom directory
             try:

--- a/patches/icu4c_android_elf64_st_info.patch
+++ b/patches/icu4c_android_elf64_st_info.patch
@@ -1,6 +1,6 @@
-diff -ur icu4c-58_2/source/tools/toolutil/pkg_genc.c icu4c-58_2.patched/source/tools/toolutil/pkg_genc.c
---- icu4c-58_2/source/tools/toolutil/pkg_genc.c	2016-06-15 20:58:17.000000000 +0200
-+++ icu4c-58_2.patched/source/tools/toolutil/pkg_genc.c	2017-02-27 10:23:39.985471339 +0100
+diff -ur icu4c-60_1/source/tools/toolutil/pkg_genc.cpp icu4c-60_1.patched/source/tools/toolutil/pkg_genc.cpp
+--- icu4c-60_1/source/tools/toolutil/pkg_genc.cpp	2016-06-15 20:58:17.000000000 +0200
++++ icu4c-60_1.patched/source/tools/toolutil/pkg_genc.cpp	2017-02-27 10:23:39.985471339 +0100
 @@ -35,6 +35,9 @@
  #       define EM_X86_64 62
  #   endif


### PR DESCRIPTION
With last version of glibc 2.26, `xlocale.h` is not provided anymore
(https://sourceware.org/glibc/wiki/Release/2.26#Removal_of_.27xlocale.h.27)

Icu has been patched (http://bugs.icu-project.org/trac/ticket/13385) so
we need to use the last version of icu.