### PR TITLE
Backport icu4c patch to not include `xlocale.h`

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -226,7 +226,8 @@ class Icu(Dependency):
 
         patches = ["icu4c_fix_static_lib_name_mingw.patch",
                    "icu4c_android_elf64_st_info.patch",
-                   "icu4c_custom_data.patch"]
+                   "icu4c_custom_data.patch",
+                   "icu4c_noxlocale.patch"]
 
 
     class Builder(MakeBuilder):

--- a/patches/icu4c_noxlocale.patch
+++ b/patches/icu4c_noxlocale.patch
@@ -1,0 +1,145 @@
+From 23f691cdee66ffabc9160a43bc68d44c1e67df96 Mon Sep 17 00:00:00 2001
+From: yoshito <yoshito@251d0590-4201-4cf1-90de-194747b24ca1>
+Date: Mon, 9 Oct 2017 14:18:53 +0000
+Subject: [PATCH] ticket:13385: Fixed a build error with glibc 2.26. Checks
+ xlocale.h availability by autoconf.
+
+git-svn-id: http://source.icu-project.org/repos/icu/trunk@40603 251d0590-4201-4cf1-90de-194747b24ca1
+
+diff --git icu4c.a/source/configure icu4c.b/source/configure
+index 61a5aac99..36c06f9ef 100755
+--- icu4c.a/source/configure
++++ icu4c.b/source/configure
+@@ -752,6 +752,7 @@ infodir
+ docdir
+ oldincludedir
+ includedir
++runstatedir
+ localstatedir
+ sharedstatedir
+ sysconfdir
+@@ -855,6 +856,7 @@ datadir='${datarootdir}'
+ sysconfdir='${prefix}/etc'
+ sharedstatedir='${prefix}/com'
+ localstatedir='${prefix}/var'
++runstatedir='${localstatedir}/run'
+ includedir='${prefix}/include'
+ oldincludedir='/usr/include'
+ docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
+@@ -1107,6 +1109,15 @@ do
+   | -silent | --silent | --silen | --sile | --sil)
+     silent=yes ;;
+ 
++  -runstatedir | --runstatedir | --runstatedi | --runstated \
++  | --runstate | --runstat | --runsta | --runst | --runs \
++  | --run | --ru | --r)
++    ac_prev=runstatedir ;;
++  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
++  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
++  | --run=* | --ru=* | --r=*)
++    runstatedir=$ac_optarg ;;
++
+   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
+     ac_prev=sbindir ;;
+   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
+@@ -1244,7 +1255,7 @@ fi
+ for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
+ 		datadir sysconfdir sharedstatedir localstatedir includedir \
+ 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
+-		libdir localedir mandir
++		libdir localedir mandir runstatedir
+ do
+   eval ac_val=\$$ac_var
+   # Remove trailing slashes.
+@@ -1397,6 +1408,7 @@ Fine tuning of the installation directories:
+   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
+   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
+   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
++  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
+   --libdir=DIR            object code libraries [EPREFIX/lib]
+   --includedir=DIR        C header files [PREFIX/include]
+   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
+@@ -7093,11 +7105,23 @@ fi
+ 
+ if test x$ac_cv_func_strtod_l = xyes
+ then
+-     CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=1"
+-     U_HAVE_STRTOD_L=1
++    U_HAVE_STRTOD_L=1
++    ac_fn_c_check_header_mongrel "$LINENO" "xlocale.h" "ac_cv_header_xlocale_h" "$ac_includes_default"
++if test "x$ac_cv_header_xlocale_h" = xyes; then :
++
++fi
++
++
++    if test "$ac_cv_header_xlocale_h" = yes; then
++      U_HAVE_XLOCALE_H=1
++      CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=1 -DU_HAVE_XLOCALE_H=1"
++    else
++      U_HAVE_XLOCALE_H=0
++      CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=1 -DU_HAVE_XLOCALE_H=0"
++    fi
+ else
+-     CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=0"
+-     U_HAVE_STRTOD_L=0
++    CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=0"
++    U_HAVE_STRTOD_L=0
+ fi
+ 
+ 
+diff --git icu4c.a/source/configure.ac icu4c.b/source/configure.ac
+index 1bd781b2b..a2fdf84ab 100644
+--- icu4c.a/source/configure.ac
++++ icu4c.b/source/configure.ac
+@@ -883,11 +883,18 @@ AC_SUBST(U_TIMEZONE)
+ AC_CHECK_FUNC(strtod_l)
+ if test x$ac_cv_func_strtod_l = xyes
+ then
+-     CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=1"
+-     U_HAVE_STRTOD_L=1
++    U_HAVE_STRTOD_L=1
++    AC_CHECK_HEADER(xlocale.h)
++    if test "$ac_cv_header_xlocale_h" = yes; then
++      U_HAVE_XLOCALE_H=1
++      CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=1 -DU_HAVE_XLOCALE_H=1"
++    else
++      U_HAVE_XLOCALE_H=0
++      CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=1 -DU_HAVE_XLOCALE_H=0"
++    fi
+ else
+-     CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=0"
+-     U_HAVE_STRTOD_L=0
++    CONFIG_CPPFLAGS="${CONFIG_CPPFLAGS} -DU_HAVE_STRTOD_L=0"
++    U_HAVE_STRTOD_L=0
+ fi
+ AC_SUBST(U_HAVE_STRTOD_L)
+ 
+diff --git icu4c.a/source/i18n/digitlst.cpp icu4c.b/source/i18n/digitlst.cpp
+index 4d7c3f4ac..8e86fa77e 100644
+--- icu4c.a/source/i18n/digitlst.cpp
++++ icu4c.b/source/i18n/digitlst.cpp
+@@ -53,6 +53,7 @@
+ #if !defined(U_USE_STRTOD_L)
+ # if U_PLATFORM_USES_ONLY_WIN32_API
+ #   define U_USE_STRTOD_L 1
++#   define U_HAVE_XLOCALE_H 0
+ # elif defined(U_HAVE_STRTOD_L)
+ #   define U_USE_STRTOD_L U_HAVE_STRTOD_L
+ # else
+@@ -61,10 +62,10 @@
+ #endif
+ 
+ #if U_USE_STRTOD_L
+-# if U_PLATFORM_USES_ONLY_WIN32_API || U_PLATFORM == U_PF_CYGWIN
+-#   include <locale.h>
+-# else
++# if U_HAVE_XLOCALE_H
+ #   include <xlocale.h>
++# else
++#   include <locale.h>
+ # endif
+ #endif
+ 
+-- 
+2.14.3
+


### PR DESCRIPTION
Last version of glibc 2.26 has removed the `xlocal.h` file.
(https://sourceware.org/glibc/wiki/Release/2.26#Removal_of_.27xlocale.h.27)

We cannot use last version of icu4c (60.1) because it used a feature not
yet exported in mingw32 releases.

So we need to backport a patch for this.

Fix #110