### PR TITLE
We must run the deploy command even on tag push.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: cpp
 dist: trusty
 sudo: required
+branches:
+  only:
+  - master
+  - /\d+\.\d+\.\d+$/
 before_install:
 - eval "${MATRIX_EVAL}"
 - ${CXX} --version
@@ -19,9 +23,17 @@ cache:
 install: travis/install_extra_deps.sh
 script: travis_wait 30 travis/compile_all.py
 deploy:
-  provider: script
-  skip_cleanup: true
-  script: travis/deploy.sh
+  - provider: script
+    skip_cleanup: true
+    script: travis/deploy.sh
+    on:
+      tags: true
+  - provider: script
+    skip_cleanup: true
+    script: travis/deploy.sh
+    on:
+      branch: master
+      condition: $TRAVIS_ENV_TYPE = cron
 env:
   global:
     - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"


### PR DESCRIPTION
In case of tag push, travis will trigger a build but will set
TRAVIS_BRANCH to the tag name, not "master".
So by default, the deploy script will be skipped in case of tag push.

There is a option "tags: true" to deploy on tag push. But it will run
deploy script ONLY on tag push, not on cron build.

So we need to set TRAVIS_TAGS to something if we are doing a cron build
to allow travis run the deploy script.