### PR TITLE
Add dependency libaria2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,3 +89,4 @@ addons:
       - gcc-mingw-w64-base
       - mingw-w64-tools
       - default-jdk
+      - autopoint

--- a/dependencies.py
+++ b/dependencies.py
@@ -193,6 +193,26 @@ class MicroHttpd(Dependency):
         configure_option = "--disable-https --without-libgcrypt --without-libcurl"
 
 
+class Aria2(Dependency):
+    name = "libaria2"
+    dependencies = ['zlib']
+
+    class Source(ReleaseDownload):
+        archive = Remotefile('libaria2-1.33.1.tar.gz',
+                             '0616f11ef3ddd0c74be74ea2536be62ce168b99e3d6a35dea9d166b9cab9fbd1',
+                             'https://github.com/aria2/aria2/archive/release-1.33.1.tar.gz')
+
+        patches = ["libaria2_android.patch"]
+
+        def _post_prepare_script(self, context):
+            context.try_skip(self.extract_path)
+            command = "autoreconf -i"
+            self.buildEnv.run_command(command, self.extract_path, context)
+
+    class Builder(MakeBuilder):
+        configure_option = "--enable-libaria2 --disable-ssl --disable-bittorent --disable-metalink"
+
+
 class Gumbo(Dependency):
     name = "gumbo"
 
@@ -323,7 +343,7 @@ class Kiwixlib(Dependency):
 
     @property
     def dependencies(self):
-        base_dependencies = ["pugixml", "libzim", "zlib", "lzma"]
+        base_dependencies = ["pugixml", "libzim", "zlib", "lzma", "libaria2"]
         if ( self.buildEnv.platform_info.build != 'android'
           and self.buildEnv.distname != 'Darwin'):
             base_dependencies += ['ctpp2c', 'ctpp2']
@@ -394,7 +414,7 @@ class AllBaseDependencies(Dependency):
 
     @property
     def dependencies(self):
-        base_deps = ['zlib', 'lzma', 'xapian-core', 'gumbo', 'pugixml', 'libmicrohttpd']
+        base_deps = ['zlib', 'lzma', 'xapian-core', 'gumbo', 'pugixml', 'libmicrohttpd', 'libaria2']
         if self.buildEnv.platform_info.build != 'native':
             base_deps += ["icu4c_cross-compile"]
         else:

--- a/dependencies.py
+++ b/dependencies.py
@@ -81,8 +81,9 @@ class lzma(Dependency):
     name = 'lzma'
 
     class Source(ReleaseDownload):
-        archive = Remotefile('xz-5.0.4.tar.bz2',
-                             '5cd9b060d3a1ad396b3be52c9b9311046a1c369e6062aea752658c435629ce92')
+        archive = Remotefile('xz-5.2.3.tar.bz2',
+                             'fd9ca16de1052aac899ad3495ad20dfa906c27b4a5070102a2ec35ca3a4740c1',
+                             'https://tukaani.org/xz/xz-5.2.3.tar.bz2')
 
     class Builder(MakeBuilder):
         @property

--- a/dependency_versions.py
+++ b/dependency_versions.py
@@ -10,7 +10,7 @@ main_project_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = '0'
+base_deps_meta_version = '1'
 
 
 base_deps_versions = {
@@ -24,4 +24,5 @@ base_deps_versions = {
   'gumbo' : '0.10.1',
   'icu4c' : '58.2',
   'Gradle' : '3.4',
+  'libaria2' : '1.33.1'
 }

--- a/dependency_versions.py
+++ b/dependency_versions.py
@@ -15,7 +15,7 @@ base_deps_meta_version = '1'
 
 base_deps_versions = {
   'zlib' : '1.2.8',
-  'lzma' : '5.0.4',
+  'lzma' : '5.2.3',
   'uuid' : '1.43.4',
   'xapian-core' : '1.4.5',
   'ctpp2' : '2.8.3',

--- a/kiwix-build.py
+++ b/kiwix-build.py
@@ -29,8 +29,8 @@ REMOTE_PREFIX = 'http://download.kiwix.org/dev/'
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
-_fedora_common = ['automake', 'cmake', 'git', 'subversion', 'ccache', 'pkgconfig', 'gcc-c++']
-_debian_common = ['automake', 'cmake', 'git', 'subversion', 'ccache', 'pkg-config', 'gcc']
+_fedora_common = ['automake', 'cmake', 'git', 'subversion', 'ccache', 'pkgconfig', 'gcc-c++', 'gettext-devel']
+_debian_common = ['automake', 'cmake', 'git', 'subversion', 'ccache', 'pkg-config', 'gcc', 'autopoint']
 PACKAGE_NAME_MAPPERS = {
     'fedora_native_dyn': {
         'COMMON': _fedora_common,

--- a/patches/libaria2_android.patch
+++ b/patches/libaria2_android.patch
@@ -1,0 +1,29 @@
+diff -ur libaria2-1.33.1/src/a2io.h libaria2-1.33.1.patched/src/a2io.h
+--- libaria2-1.33.1/src/a2io.h	2017-11-08 13:39:06.000000000 +0100
++++ libaria2-1.33.1.patched/src/a2io.h	2018-03-27 17:02:45.651414060 +0200
+@@ -147,7 +147,7 @@
+ // # define a2fseek(fp, offset, origin): No fseek64 and not used in aria2
+ #define a2fstat(fd, buf) fstat64(fd, buf)
+ // # define a2ftell(fd): No ftell64 and not used in aria2
+-#define a2_struct_stat struct stat
++#define a2_struct_stat struct stat64
+ #define a2stat(path, buf) stat64(path, buf)
+ #define a2mkdir(path, openMode) mkdir(path, openMode)
+ #define a2utimbuf utimbuf
+diff -ur libaria2-1.33.1/src/crypto_endian.h libaria2-1.33.1.patched/src/crypto_endian.h
+--- libaria2-1.33.1/src/crypto_endian.h	2017-11-08 13:39:06.000000000 +0100
++++ libaria2-1.33.1.patched/src/crypto_endian.h	2018-03-27 16:56:55.264371501 +0200
+@@ -33,9 +33,13 @@
+ #define BIG_ENDIAN 4321
+ #define BYTE_ORDER LITTLE_ENDIAN
+ #else // !  defined(_WIN32) || defined(__INTEL_COMPILER) || defined (_MSC_VER)
++#if defined(__ANDROID__)
++#include <endian.h>
++#else // defined(__ANDROID__)
+ #ifdef HAVE_SYS_PARAM_H
+ #include <sys/param.h>
+ #endif // HAVE_SYS_PARAM_H
++#endif // defined(__ANDROID__)
+ #endif // !  defined(_WIN32) || defined(__INTEL_COMPILER) || defined (_MSC_VER)
+ 
+ #if !defined(LITTLE_ENDIAN) || !defined(BIG_ENDIAN) || !defined(BYTE_ORDER) || \


### PR DESCRIPTION
libaria2 needs a lot of dependencies to handle all protocol.
So this is a basic compilation of libaria2 :
No tls(https), no metalink and no bit-torrent.