### PR TITLE
Do not do unecessary build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ branches:
   only:
   - master
   - /\d+\.\d+\.\d+$/
+if: type != push OR tag IS present
 before_install:
 - eval "${MATRIX_EVAL}"
 - ${CXX} --version


### PR DESCRIPTION
Build only if the travis event is not a push (pull_request, cron, ..)
or we are pushing a tag (to build releases).