### PR TITLE
Better compilation of icu4c.

### DIFF
--- a/kiwixbuild/dependencies/icu4c.py
+++ b/kiwixbuild/dependencies/icu4c.py
@@ -19,7 +19,8 @@ class Icu(Dependency):
                    "icu4c_android_elf64_st_info.patch",
                    "icu4c_custom_data.patch",
                    "icu4c_noxlocale.patch",
-                   "icu4c_rpath.patch"]
+                   "icu4c_rpath.patch",
+                   "icu4c_build_config.patch"]
 
 
     class Builder(MakeBuilder):
@@ -32,7 +33,9 @@ class Icu(Dependency):
 
         @property
         def configure_option(self):
-            options = "--disable-samples --disable-tests --disable-extras --disable-dyload --enable-rpath"
+            options = ("--disable-samples --disable-tests --disable-extras "
+                       "--disable-dyload --enable-rpath "
+                       "--disable-icuio --disable-layoutex")
             platformInfo = self.buildEnv.platformInfo
             if platformInfo.build != 'native':
                 icu_native_builder = get_target_step(

--- a/kiwixbuild/patches/icu4c_build_config.patch
+++ b/kiwixbuild/patches/icu4c_build_config.patch
@@ -1,0 +1,36 @@
+diff -ur icu4c/source/common/unicode/platform.h icu4c.patched/source/common/unicode/platform.h
+--- icu4c/source/common/unicode/platform.h	2018-04-17 17:20:31.048946098 +0200
++++ icu4c.patched/source/common/unicode/platform.h	2018-06-11 11:22:40.692327158 +0200
+@@ -644,7 +644,7 @@
+ #elif U_PLATFORM == U_PF_ANDROID || U_PLATFORM_IS_DARWIN_BASED
+ #   define U_CHARSET_IS_UTF8 1
+ #else
+-#   define U_CHARSET_IS_UTF8 0
++#   define U_CHARSET_IS_UTF8 1
+ #endif
+ 
+ /** @} */
+diff -ur icu4c/source/common/unicode/uconfig.h icu4c.patched/source/common/unicode/uconfig.h
+--- icu4c/source/common/unicode/uconfig.h	2018-04-17 17:20:31.072946266 +0200
++++ icu4c.patched/source/common/unicode/uconfig.h	2018-06-11 11:26:24.512936322 +0200
+@@ -107,7 +107,7 @@
+       defined(U_TOOLUTIL_IMPLEMENTATION)
+ #   define U_NO_DEFAULT_INCLUDE_UTF_HEADERS 1
+ #else
+-#   define U_NO_DEFAULT_INCLUDE_UTF_HEADERS 0
++#   define U_NO_DEFAULT_INCLUDE_UTF_HEADERS 1
+ #endif
+ 
+ /**
+diff -ur icu4c/source/common/unicode/uversion.h icu4c.patched/source/common/unicode/uversion.h
+--- icu4c/source/common/unicode/uversion.h	2018-04-17 17:20:31.086946363 +0200
++++ icu4c.patched/source/common/unicode/uversion.h	2018-06-11 11:20:27.093375709 +0200
+@@ -122,7 +122,7 @@
+ #   define U_NAMESPACE_QUALIFIER U_ICU_NAMESPACE::
+ 
+ #   ifndef U_USING_ICU_NAMESPACE
+-#       define U_USING_ICU_NAMESPACE 1
++#       define U_USING_ICU_NAMESPACE 0
+ #   endif
+ #   if U_USING_ICU_NAMESPACE
+         U_NAMESPACE_USE

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -10,7 +10,7 @@ main_project_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = '5'
+base_deps_meta_version = '6'
 
 
 base_deps_versions = {


### PR DESCRIPTION
- Disable icuio and layoutex.
- Hardcode UTF8 as charset (we always use utf8 and hardcoding him improve
  performances)
- Do not include default utf headers
- Do not use `using namespace icu`

See http://source.icu-project.org/repos/icu/trunk/icu4c/readme.html#RecBuild
for more information about options.

Increment base dependencies version as we are compiling icu differently.