### PR TITLE
Try to decrypt the secret key only if we will do a deployement.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ if: type != push OR tag IS present
 before_install:
 - PATH=$PATH:${HOME}/bin
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then PATH=$PATH:$(brew --prefix)/opt/gettext/bin; fi
-- openssl aes-256-cbc -K $encrypted_eba2f7543984_key -iv $encrypted_eba2f7543984_iv
-  -in travis/travisci_builder_id_key.enc -out travis/travisci_builder_id_key -d
-- chmod 600 travis/travisci_builder_id_key
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
@@ -37,6 +34,10 @@ script:
     travis/compile_all.py
   fi
 after_failure: travis/upload_all_log.sh
+before_deploy:
+- openssl aes-256-cbc -K $encrypted_eba2f7543984_key -iv $encrypted_eba2f7543984_iv
+  -in travis/travisci_builder_id_key.enc -out travis/travisci_builder_id_key -d
+- chmod 600 travis/travisci_builder_id_key
 deploy:
   - provider: script
     skip_cleanup: true


### PR DESCRIPTION
Is a contributor do a PR from its own repository, we will try do decrypt
the key but fail because secret env var are not available.

We need the secret key only if we do a deployement and the deployement is
done only for a tag or a cron job.