### PR TITLE
[TRAVIS] Try to use arch specific base_deps when build android multi arch.

### DIFF
--- a/kiwixbuild/utils.py
+++ b/kiwixbuild/utils.py
@@ -248,10 +248,23 @@ def run_command(command, cwd, context, buildEnv=None, env=None, input=None, cros
             kwargs['stdin'] = subprocess.PIPE
         process = subprocess.Popen(command, shell=True, cwd=cwd, env=env, stdout=log or sys.stdout, stderr=subprocess.STDOUT, **kwargs)
         if input:
-            process.communicate(input.encode())
-        retcode = process.wait()
-        if retcode:
-            raise subprocess.CalledProcessError(retcode, command)
+            input = input.encode()
+        while True:
+            try:
+                if input is None:
+                    process.wait(timeout=30)
+                else:
+                    process.communicate(input, timeout=30)
+            except subprocess.TimeoutExpired:
+                # Either `wait` timeout (and `input` is None) or
+                # `communicate` timeout (and we must set `input` to None
+                # to not communicate again).
+                input = None
+                print('.', end='', flush=True)
+            else:
+                break
+        if process.returncode:
+            raise subprocess.CalledProcessError(process.returncode, command)
     finally:
         if log:
             log.close()

--- a/travis/compile_all.py
+++ b/travis/compile_all.py
@@ -195,8 +195,13 @@ def make_deps_archive(target, full=False):
         files_to_archive += HOME.glob('**/TOOLCHAINS')
         relative_path = HOME
 
+    counter = 50
     with tarfile.open(str(relative_path/archive_name), 'w:gz') as tar:
         for name in set(files_to_archive):
+            counter -= 1
+            if not counter:
+                print('.', end='', flush=True)
+                counter = 50
             tar.add(str(name), arcname=str(name.relative_to(relative_path)))
     return relative_path/archive_name
 


### PR DESCRIPTION
Compiling all dependencies for all archs takes a too long time for travis.
By downloading the cache of specific android arch, we avoid to recompile
them.