### PR TITLE
[TRAVIS] Allways use $HOME as relative path in dependencies archives.

### DIFF
--- a/travis/compile_all.py
+++ b/travis/compile_all.py
@@ -180,7 +180,7 @@ def make_deps_archive(target, full=False):
     write_manifest(manifest_file, archive_name, target, PLATFORM)
     files_to_archive.append(manifest_file)
 
-    relative_path = BASE_DIR
+    relative_path = HOME
     if full:
         files_to_archive += ARCHIVE_DIR.glob(".*_ok")
         files_to_archive += BASE_DIR.glob('*/.*_ok')
@@ -193,7 +193,6 @@ def make_deps_archive(target, full=False):
         files_to_archive += HOME.glob('BUILD_*/pugixml-{}'.format(
             base_deps_versions['pugixml']))
         files_to_archive += HOME.glob('**/TOOLCHAINS')
-        relative_path = HOME
 
     counter = 50
     with tarfile.open(str(relative_path/archive_name), 'w:gz') as tar:


### PR DESCRIPTION
As we now move to multi-arch build, we may have things compiled natively
or "neutral" (as toolchains). So we cannot use the BASE_DIR as
relative_path because BASE_DIR is arch dependent.