### PR TITLE
[TRAVIS] Do not make a deps archive when PLATFORM is android.

### DIFF
--- a/travis/compile_all.py
+++ b/travis/compile_all.py
@@ -308,7 +308,7 @@ else:
     TARGETS = ('libzim', 'zim-tools', 'kiwix-lib', 'kiwix-tools')
 
 for target in TARGETS:
-    if environ['TRAVIS_EVENT_TYPE'] == 'cron':
+    if environ['TRAVIS_EVENT_TYPE'] == 'cron' and PLATFORM != 'android':
         run_kiwix_build(target,
                         platform=PLATFORM,
                         build_deps_only=True)


### PR DESCRIPTION
We never use the android platform in other project. We always an arch
specific android platform (android_arm).

So, do not try to do any dependencies archives there.
Especially if travis kill the job because it takes too long to create
the archive.