### PR TITLE
[AppVeyor] No windows branch for kiwix-desktop.

### DIFF
--- a/appveyor/install_kiwix-desktop.cmd
+++ b/appveyor/install_kiwix-desktop.cmd
@@ -2,7 +2,6 @@ REM ========================================================
 REM Install kiwix-desktop
 git clone https://github.com/kiwix/kiwix-desktop || exit /b 1
 cd kiwix-desktop
-git checkout windows
 echo "Getting fix_desktop"
 curl -fsSL -O http://public.kymeria.fr/KIWIX/windows/fix_desktop_makefile.py_ || exit /b 1
 echo "Running qmake"


### PR DESCRIPTION
The `windows` branch has been merge. We should directly use `master` now.