### PR TITLE
Fix the path of AppVeyor Qt to be minor version independent.

### DIFF
--- a/appveyor/package_kiwix-desktop.sh
+++ b/appveyor/package_kiwix-desktop.sh
@@ -10,7 +10,7 @@ mkdir $KIWIX_DIR
 mkdir -p NIGHTLY_KIWIX_ARCHIVES_DIR
 
 cp /c/projects/kiwix-build/kiwix-desktop/Release/kiwix-desktop.exe $KIWIX_DIR
-/c/Qt/5.11.0/msvc2017_64/bin/windeployqt --compiler-runtime $KIWIX_DIR
+/c/Qt/5.11/msvc2017_64/bin/windeployqt --compiler-runtime $KIWIX_DIR
 
 cp $MINGW64_EXTRA_DIR/bin/*.dll $KIWIX_DIR
 


### PR DESCRIPTION
AppVeyor may update minor version of Qt and change `5.11.0` to `5.11.1`.
If we use the path with the full version, it will break in the futur.

AppVeyor install a link `5.11` pointing to the last version, so let's use
it.