### PR TITLE
Sign the application after windeployqt.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,7 +49,6 @@ build_script:
 
 before_deploy:
   - cmd: openssl enc -d -aes-256-cbc -md sha256 -pass pass:%win_certificate_secret% -in appveyor\kiwix.p12.enc -out appveyor\kiwix.pfx
-  - cmd: signtool.exe sign /f appveyor\kiwix.pfx /p %win_certificate_password% /t http://timestamp.verisign.com/scripts/timstamp.dll /d "Kiwix-desktop application" C:\projects\kiwix-build\kiwix-desktop\Release\kiwix-desktop.exe
   - cmd: '%MINGW64_RUN% "cd /c/projects/kiwix-build && appveyor/package_kiwix-desktop.sh"'
   - cmd: openssl enc -d -aes-256-cbc -md sha256 -pass pass:%ENC_PASSWD% -in appveyor\nightlybot_id_key.enc -out appveyor\nightlybot_id_key
 

--- a/appveyor/install_icu.cmd
+++ b/appveyor/install_icu.cmd
@@ -3,5 +3,5 @@ REM Install icu
 curl -SL -O http://public.kymeria.fr/KIWIX/windows/icu4c-62_1-Win64-MSVC2017.zip || exit /b 1
 7z x icu4c-62_1-Win64-MSVC2017.zip -o%EXTRA_DIR% -r include || exit /b 1
 7z e icu4c-62_1-Win64-MSVC2017.zip -o%EXTRA_DIR%\lib lib64\* || exit /b 1
-7z e icu4c-62_1-Win64-MSVC2017.zip -o%EXTRA_DIR%\bin bin\*.dll || exit /b 1
+7z e icu4c-62_1-Win64-MSVC2017.zip -o%EXTRA_DIR%\bin bin64\*.dll || exit /b 1
 curl -fsSL -o%PKG_CONFIG_PATH%\icu-i18n.pc http://public.kymeria.fr/KIWIX/windows/icu-i18n.pc || exit /b 1

--- a/appveyor/package_kiwix-desktop.sh
+++ b/appveyor/package_kiwix-desktop.sh
@@ -14,4 +14,6 @@ cp /c/projects/kiwix-build/kiwix-desktop/Release/kiwix-desktop.exe $KIWIX_DIR
 
 cp $MINGW64_EXTRA_DIR/bin/*.dll $KIWIX_DIR
 
+/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/x64/signtool.exe sign -f appveyor/kiwix.pfx -p $win_certificate_password -t http://timestamp.verisign.com/scripts/timestamp.dll -d "Kiwix-desktop application" $KIWIX_DIR/kiwix-desktop.exe
+
 7z a -tzip $NIGHTLY_KIWIX_ARCHIVES_DIR/$KIWIX_ARCH_NAME $KIWIX_DIR


### PR DESCRIPTION
windeployqt modify the executable, so we must sign it after.