### PR TITLE
Always use api 21 for android ndk.

### DIFF
--- a/kiwixbuild/dependencies/android_ndk.py
+++ b/kiwixbuild/dependencies/android_ndk.py
@@ -27,7 +27,7 @@ class android_ndk(Dependency):
 
         @property
         def api(self):
-            return '21' if self.arch in ('arm64', 'mips64', 'x86_64') else '14'
+            return '21'
 
         @property
         def platform(self):

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -10,7 +10,7 @@ main_project_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = '11'
+base_deps_meta_version = '12'
 
 
 base_deps_versions = {


### PR DESCRIPTION
mmap64 is supported only from api 21
(https://android.googlesource.com/platform/ndk/+/master/docs/user/common_problems.md)

Let's move to api 21 all the time.