### PR TITLE
Do not use buffered header on android.

### DIFF
--- a/kiwixbuild/dependencies/libzim.py
+++ b/kiwixbuild/dependencies/libzim.py
@@ -13,3 +13,11 @@ class Libzim(Dependency):
     class Builder(MesonBuilder):
         test_option = "-t 8"
         dependencies = ['zlib', 'lzma', 'xapian-core', 'icu4c']
+
+        @property
+        def configure_option(self):
+            options = ""
+            platformInfo = self.buildEnv.platformInfo
+            if platformInfo.build == 'android':
+                options += "-DUSE_BUFFER_HEADER=false"
+            return options


### PR DESCRIPTION
Android devices are low memory devices, use last libzim compilation option
to avoid copy/mmap index header in memory.

Depends of https://github.com/openzim/libzim/pull/178