### PR TITLE
Add a basic implementation of Flatpak support

### DIFF
--- a/kiwixbuild/dependencies/__init__.py
+++ b/kiwixbuild/dependencies/__init__.py
@@ -13,6 +13,7 @@ from . import (
     kiwix_android,
     kiwix_custom_app,
     kiwix_desktop,
+    kiwix_desktop_flatpak,
     kiwix_lib,
     kiwix_tools,
     libaria2,

--- a/kiwixbuild/dependencies/kiwix_desktop.py
+++ b/kiwixbuild/dependencies/kiwix_desktop.py
@@ -11,7 +11,14 @@ class KiwixDesktop(Dependency):
         git_dir = "kiwix-desktop"
 
     class Builder(QMakeBuilder):
-        dependencies = ["qt", "qtwebengine", "kiwix-lib"]
+        @classmethod
+        def get_dependencies(cls, platformInfo, allDeps):
+            core_dependencies = ["kiwix-lib"]
+            if (platformInfo.build == 'flatpak'):
+                return core_dependencies
+            dependencies = core_dependencies + ["qt", "qtwebengine"]
+            return dependencies
+
         @property
         def configure_option(self):
             options = ["PREFIX={}".format(self.buildEnv.install_dir)]

--- a/kiwixbuild/dependencies/kiwix_desktop_flatpak.py
+++ b/kiwixbuild/dependencies/kiwix_desktop_flatpak.py
@@ -1,0 +1,242 @@
+from .base import (
+    Dependency,
+    Source,
+    Builder,
+    ReleaseDownload,
+    GitClone,
+    MesonBuilder,
+    CMakeBuilder,
+    QMakeBuilder,
+    MakeBuilder,
+    SCRIPT_DIR)
+import kiwixbuild.versions as versions
+from kiwixbuild.utils import pj, run_command, REMOTE_PREFIX
+from kiwixbuild._global import neutralEnv
+from shutil import copyfile
+import json
+import os
+
+class KiwixDesktopFlatpak(Dependency):
+    name = "kiwix-desktop-flatpak"
+    flatpak = {
+        'remote': {
+            'name': 'flathub',
+            'url': 'https://flathub.org/repo/flathub.flatpakrepo'
+        },
+        'manifest': {
+            'id': 'org.kiwix.Client',
+            'runtime': 'org.kde.Platform',
+            'runtime-version': '5.11',
+            'sdk': 'org.kde.Sdk',
+            'command': 'kiwix-desktop',
+            'finish-args': [
+                '--socket=wayland',
+                '--socket=x11',
+                '--share=ipc',
+                '--device=dri',
+                '--socket=pulseaudio'
+            ],
+            'cleanup': [
+                '/include',
+                '/lib/pkgconfig',
+                '/lib/cmake',
+                '/lib/*.la',
+                '/bin/aria2c',
+                '/bin/copydatabase',
+                '/bin/kiwix-compile-resources',
+                '/bin/quest',
+                '/bin/simple*',
+                '/bin/xapian-*',
+                '/share/aclocal',
+                '/share/doc',
+                '/share/man'
+            ]
+        },
+        'dependencies': ['kiwix-desktop']
+    }
+    # This will be configured during Source.prepare step
+    flatpak_dir = ''
+    flatpak_env = {}
+
+    class Source(Source):
+        def _setup_flatpak(self):
+            flatpak_dir = pj(neutralEnv('toolchain_dir'), 'flatpak')
+            os.makedirs(flatpak_dir, exist_ok=True)
+            flatpak_env = {
+                'FLATPAK_USER_DIR': flatpak_dir
+            }
+            self.target.flatpak_dir = flatpak_dir
+            self.target.flatpak_env = flatpak_env
+
+        def _remote(self, context):
+            command = "flatpak --user remote-add --if-not-exists {remote_name} {remote_url}"
+            command = command.format(
+                remote_name = self.target.flatpak['remote']['name'],
+                remote_url = self.target.flatpak['remote']['url']
+            )
+            run_command(command, '.', context, None, self.target.flatpak_env)
+
+        def _runtimes(self, context):
+            command = "flatpak --user install -y {remote_name} {sdk}//{version} {platform}//{version}"
+            command = command.format(
+                remote_name = self.target.flatpak['remote']['name'],
+                sdk = self.target.flatpak['manifest']['sdk'],
+                platform = self.target.flatpak['manifest']['runtime'],
+                version = self.target.flatpak['manifest']['runtime-version']
+            )
+            run_command(command, '.', context, None, self.target.flatpak_env)
+
+        def prepare(self):
+            self._setup_flatpak()
+            self.command('remote', self._remote)
+            self.command('runtimes', self._runtimes)
+
+    class Builder(Builder):
+        def _get_all_dependencies(self, dependencies, platformInfo, all_deps):
+            packages = []
+            for package in dependencies:
+                dep = all_deps[package]
+                deps = dep.Builder.get_dependencies(platformInfo, all_deps)
+                sub_packages = self._get_all_dependencies(deps, platformInfo, all_deps)
+                packages += [package] + sub_packages
+            return packages
+
+        def _get_version(self, package, versions):
+            for item in dir(versions):
+                if item.endswith('versions'):
+                    result = getattr(versions, item)
+                    if package in result:
+                        return result[package]
+
+        def _generate_modules(self, deps):
+            modules = []
+            for dep in deps:
+                module = self._generate_module(dep)
+                modules.append(module)
+            return modules
+
+        def _generate_module(self, dep):
+            module = {
+                'name': dep.name
+            }
+
+            # buildsystem and builddir
+            if issubclass(dep.Builder, MesonBuilder):
+                module['buildsystem'] = 'meson'
+                module['builddir'] = True
+            elif issubclass(dep.Builder, CMakeBuilder):
+                module['buildsystem'] = 'cmake'
+                module['builddir'] = True
+            elif issubclass(dep.Builder, QMakeBuilder):
+                module['buildsystem'] = 'qmake'
+
+            # no-autogen
+            if hasattr(dep.Source, 'flatpak_no_autogen'):
+                module['no-autogen'] = dep.Source.flatpak_no_autogen
+
+            # config-opts
+            if hasattr(dep.Builder, 'configure_option') and \
+                isinstance(dep.Builder.configure_option, str) and \
+                dep.Builder.configure_option != '':
+                module['config-opts'] = dep.Builder.configure_option.split(' ')
+
+            sources = self._generate_sources(dep)
+            module['sources'] = sources
+
+            return module
+
+        def _generate_sources(self, dep):
+            sources = []
+            # archive and git
+            if issubclass(dep.Source, ReleaseDownload):
+                source = {
+                    'type': 'archive',
+                    'sha256': dep.Source.archive.sha256
+                }
+
+                if dep.Source.archive.url != None:
+                    source['url'] = dep.Source.archive.url
+                else:
+                    source['url'] = REMOTE_PREFIX + dep.Source.archive.name
+
+                if hasattr(dep.Source, 'flatpak_dest'):
+                    source['dest'] = dep.Source.flatpak_dest
+                sources = [source]
+            elif issubclass(dep.Source, GitClone):
+                source = {
+                    'type': 'git',
+                    'url': dep.Source.git_remote,
+                    'tag': self._get_version(dep.name, versions)
+                }
+                sources = [source]
+
+            # patches
+            if hasattr(dep.Source, 'patches'):
+                for p in dep.Source.patches:
+                    patch = {
+                        'type': 'patch',
+                        'path': 'patches/' + p
+                    }
+                    sources += [patch]
+
+            # shell
+            if hasattr(dep.Source, 'flatpak_command'):
+                source = {
+                    'type': 'shell',
+                    'commands': [
+                        dep.Source.flatpak_command
+                    ]
+                }
+                sources += [source]
+
+            return sources
+
+        def _copy_patches(self, deps):
+            for dep in deps:
+                if hasattr(dep.Source, 'patches'):
+                    for p in dep.Source.patches:
+                        path = pj(SCRIPT_DIR, 'patches', p)
+                        os.makedirs(pj(self.build_path, 'patches'), exist_ok=True)
+                        dest = pj(self.build_path, 'patches', p)
+                        copyfile(path, dest)
+
+        def _configure(self, context):
+            os.makedirs(self.build_path, exist_ok=True)
+
+            # get dependencies
+            packages = self._get_all_dependencies(self.target.flatpak['dependencies'], self.buildEnv.platformInfo, Dependency.all_deps)
+            deps = []
+            for package in packages:
+                deps.append(Dependency.all_deps[package])
+            deps.reverse()
+
+            # build manifest
+            manifest = self.target.flatpak['manifest']
+            modules = self._generate_modules(deps)
+            manifest['modules'] = modules
+
+            # write manifest
+            file = open(pj(self.build_path, 'manifest.json'),'w')
+            file.write(json.dumps(manifest, indent=4))
+            file.close()
+
+            self._copy_patches(deps)
+
+        def _build(self, context):
+            command = "flatpak-builder --ccache --force-clean --repo=repo builddir manifest.json"
+            run_command(command, self.build_path, context, None, self.target.flatpak_env)
+
+        def _bundle(self, context):
+            command = "flatpak build-bundle repo {id}.flatpak {id}"
+            command = command.format(
+                id = self.target.flatpak['manifest']['id']
+            )
+            run_command(command, self.build_path, context, None, self.target.flatpak_env)
+
+        def build(self):
+            self.command('configure', self._configure)
+            self.command('build', self._build)
+            self.command('bundle', self._bundle)
+
+        def make_dist(self):
+            pass

--- a/kiwixbuild/dependencies/kiwix_desktop_flatpak.py
+++ b/kiwixbuild/dependencies/kiwix_desktop_flatpak.py
@@ -9,7 +9,6 @@ from .base import (
     QMakeBuilder,
     MakeBuilder,
     SCRIPT_DIR)
-import kiwixbuild.versions as versions
 from kiwixbuild.utils import pj, run_command, REMOTE_PREFIX
 from kiwixbuild._global import neutralEnv
 from shutil import copyfile
@@ -101,13 +100,6 @@ class KiwixDesktopFlatpak(Dependency):
                 packages += [package] + sub_packages
             return packages
 
-        def _get_version(self, package, versions):
-            for item in dir(versions):
-                if item.endswith('versions'):
-                    result = getattr(versions, item)
-                    if package in result:
-                        return result[package]
-
         def _generate_modules(self, deps):
             modules = []
             for dep in deps:
@@ -166,7 +158,7 @@ class KiwixDesktopFlatpak(Dependency):
                 source = {
                     'type': 'git',
                     'url': dep.Source.git_remote,
-                    'tag': self._get_version(dep.name, versions)
+                    'tag': dep.version()
                 }
                 sources = [source]
 

--- a/kiwixbuild/dependencies/kiwix_lib.py
+++ b/kiwixbuild/dependencies/kiwix_lib.py
@@ -14,7 +14,10 @@ class Kiwixlib(Dependency):
     class Builder(MesonBuilder):
         @classmethod
         def get_dependencies(cls, platformInfo, allDeps):
-            base_dependencies = ["pugixml", "libzim", "zlib", "lzma", "libaria2", "icu4c"]
+            core_dependencies = ["pugixml", "libzim", "libaria2"]
+            if (platformInfo.build == 'flatpak'):
+                return core_dependencies
+            base_dependencies = core_dependencies + ["zlib", "lzma", "icu4c"]
             if (platformInfo.build != 'android' and
                 neutralEnv('distname') != 'Darwin'):
                 base_dependencies += ['ctpp2c', 'ctpp2']

--- a/kiwixbuild/dependencies/libaria2.py
+++ b/kiwixbuild/dependencies/libaria2.py
@@ -15,6 +15,9 @@ class Aria2(Dependency):
                              'https://github.com/aria2/aria2/archive/release-1.33.1.tar.gz')
 
         patches = ["libaria2_android.patch"]
+        flatpak_no_autogen = True
+        # Run it twice to pass `too many loops` error
+        flatpak_command = "autoreconf -i; autoreconf -i"
 
         def _post_prepare_script(self, context):
             context.try_skip(self.extract_path)
@@ -22,5 +25,9 @@ class Aria2(Dependency):
             run_command(command, self.extract_path, context)
 
     class Builder(MakeBuilder):
-        dependencies = ['zlib']
         configure_option = "--enable-libaria2 --disable-ssl --disable-bittorent --disable-metalink --without-sqlite3 --without-libxml2 --without-libexpat"
+        @classmethod
+        def get_dependencies(cls, platformInfo, allDeps):
+            if (platformInfo.build == 'flatpak'):
+                return []
+            return ['zlib']

--- a/kiwixbuild/dependencies/libzim.py
+++ b/kiwixbuild/dependencies/libzim.py
@@ -12,7 +12,13 @@ class Libzim(Dependency):
 
     class Builder(MesonBuilder):
         test_option = "-t 8"
-        dependencies = ['zlib', 'lzma', 'xapian-core', 'icu4c']
+        @classmethod
+        def get_dependencies(cls, platformInfo, allDeps):
+            core_dependencies = ['xapian-core']
+            if (platformInfo.build == 'flatpak'):
+                return core_dependencies
+            dependencies = core_dependencies + ['zlib', 'lzma', 'icu4c']
+            return dependencies
 
         @property
         def configure_option(self):

--- a/kiwixbuild/dependencies/pugixml.py
+++ b/kiwixbuild/dependencies/pugixml.py
@@ -12,5 +12,6 @@ class Pugixml(Dependency):
         archive = Remotefile('pugixml-1.2.tar.gz',
                              '0f422dad86da0a2e56a37fb2a88376aae6e931f22cc8b956978460c9db06136b')
         patches = ["pugixml_meson.patch"]
+        flatpak_dest = "src"
 
     Builder = MesonBuilder

--- a/kiwixbuild/dependencies/xapian.py
+++ b/kiwixbuild/dependencies/xapian.py
@@ -23,6 +23,8 @@ class Xapian(Dependency):
 
         @classmethod
         def get_dependencies(cls, platformInfo, allDeps):
+            if (platformInfo.build == 'flatpak'):
+                return []
             deps = ['zlib', 'lzma']
             if (platformInfo.build == 'win32'
              or neutralEnv('distname') == 'Darwin'):

--- a/kiwixbuild/packages.py
+++ b/kiwixbuild/packages.py
@@ -51,6 +51,9 @@ PACKAGE_NAME_MAPPERS = {
     'fedora_android': {
         'COMMON': _fedora_common + ['java-1.8.0-openjdk-devel']
     },
+    'fedora_flatpak': {
+        'COMMON': ['flatpak', 'flatpak-builder']
+    },
     'debian_native_dyn': {
         'COMMON': _debian_common + ['libbz2-dev', 'libmagic-dev'],
         'zlib': ['zlib1g-dev'],
@@ -93,6 +96,9 @@ PACKAGE_NAME_MAPPERS = {
     'debian_android': {
         'COMMON': _debian_common + ['default-jdk'],
         'ctpp2c': ['ctpp2-utils'],
+    },
+    'debian_flatpak': {
+        'COMMON': ['flatpak', 'flatpak-builder']
     },
     'Darwin_native_dyn': {
         'COMMON': ['autoconf', 'automake', 'libtool', 'cmake', 'pkg-config'],

--- a/kiwixbuild/platforms/__init__.py
+++ b/kiwixbuild/platforms/__init__.py
@@ -4,6 +4,7 @@ from .base import *
 from . import (
     android,
     armhf,
+    flatpak,
     i586,
     ios,
     native,

--- a/kiwixbuild/platforms/flatpak.py
+++ b/kiwixbuild/platforms/flatpak.py
@@ -1,0 +1,11 @@
+from .base import PlatformInfo
+from kiwixbuild._global import option, neutralEnv
+
+class FlatpakPlatformInfo(PlatformInfo):
+    name = 'flatpak'
+    build = 'flatpak'
+    static = ''
+    compatible_hosts = ['debian', 'fedora']
+
+    def __str__(self):
+        return "flatpak"


### PR DESCRIPTION
First draft that works, but I think it does not fully respect the design of the build system. I tried to modify as few files as possible to avoid breaking it. `kiwix_desktop_flatpak.py` shows some little tricks I had to use, because I didn't yet understand the architecture well or because I had no choice, or both 😉

For information, `flatpak-builder` must have at least version `0.9.11` because it supports the build system `qmake`. This means Ubuntu must be used in its minimal `bionic` version and therefore this PR does not work with your current `travis` configuration. In addition, the Docker container must be launched in privileged mode (`--privileged`): https://github.com/flatpak/flatpak/issues/1326

As @mgautierfr said in the relative [issue](https://github.com/kiwix/kiwix-build/issues/249), in the future the ideal solution (for Linux) will probably be to use [Buildstream](https://gitlab.com/BuildStream/buildstream), which will therefore theoretically support the build to deb, rpm, Flatpak, or standalone with less effort. In the meantime, I think it is useless to spend too much energy and it's better to wait until the light turns green.

The command to start the build:

```
kiwix-build --target-platform flatpak kiwix-desktop-flatpak
```