### PR TITLE
We need to deploy the real lib, not the symlink to it.

### DIFF
--- a/travis/compile_all.py
+++ b/travis/compile_all.py
@@ -43,7 +43,7 @@ BINARIES = {
     'kiwix-tools': ('bin', ('kiwix-manage', 'kiwix-read', 'kiwix-search', 'kiwix-serve')),
     'zim-tools': ('bin', ('zimbench', 'zimcheck', 'zimdump', 'zimsearch', 'zimdiff', 'zimpatch', 'zimsplit')),
     'zimwriterfs': ('bin', ('zimwriterfs',)),
-    'libzim': ('lib/x86_64-linux-gnu', ('libzim.so',))
+    'libzim': ('lib/x86_64-linux-gnu', ('libzim.so.{}'.format(main_project_versions['libzim']),))
 }
 
 _date = date.today().isoformat()


### PR DESCRIPTION
`libzim.so` is a symlink to `libzim.so.4`, who is also a symlink to
`libzim.so.4.0.4`.