### PR TITLE
Build in release mode.

### DIFF
--- a/kiwixbuild/dependencies/icu4c.py
+++ b/kiwixbuild/dependencies/icu4c.py
@@ -23,6 +23,7 @@ class Icu(Dependency):
 
     class Builder(MakeBuilder):
         subsource_dir = "source"
+        make_install_target = "install"
 
         @classmethod
         def get_dependencies(cls, platformInfo, allDeps):

--- a/kiwixbuild/dependencies/kiwix_desktop.py
+++ b/kiwixbuild/dependencies/kiwix_desktop.py
@@ -12,6 +12,8 @@ class KiwixDesktop(Dependency):
 
     class Builder(QMakeBuilder):
         dependencies = ["qt", "qtwebengine", "kiwix-lib", "aria2"]
+        make_install_target = 'install'
+
         @property
         def configure_option(self):
             if self.buildEnv.platformInfo.name == 'flatpak':

--- a/kiwixbuild/dependencies/pugixml.py
+++ b/kiwixbuild/dependencies/pugixml.py
@@ -14,4 +14,6 @@ class Pugixml(Dependency):
         patches = ["pugixml_meson.patch"]
         flatpak_dest = "src"
 
-    Builder = MesonBuilder
+    class Builder(MesonBuilder):
+        build_type = 'release'
+        strip_option = ''

--- a/kiwixbuild/dependencies/xapian.py
+++ b/kiwixbuild/dependencies/xapian.py
@@ -24,6 +24,7 @@ class Xapian(Dependency):
         configure_env = {'_format_LDFLAGS': "{env.LDFLAGS} -L{buildEnv.install_dir}/{buildEnv.libprefix}",
                          '_format_CXXFLAGS': "{env.CXXFLAGS} -I{buildEnv.install_dir}/include"}
 
+
         @classmethod
         def get_dependencies(cls, platformInfo, allDeps):
             deps = ['zlib', 'lzma']

--- a/kiwixbuild/dependencies/zlib.py
+++ b/kiwixbuild/dependencies/zlib.py
@@ -20,6 +20,7 @@ class zlib(Dependency):
     class Builder(MakeBuilder):
         dynamic_configure_option = "--shared"
         static_configure_option = "--static"
+        make_install_target = 'install'
         configure_option_template = "{dep_options} {static_option} --prefix {install_dir} --libdir {libdir}"
 
         def _pre_build_script(self, context):

--- a/kiwixbuild/platforms/android.py
+++ b/kiwixbuild/platforms/android.py
@@ -66,8 +66,8 @@ class AndroidPlatformInfo(PlatformInfo):
 
     def set_compiler(self, env):
         binaries = self.binaries(self.ndk_builder.install_path)
-        env['CC'] = binaries['CC']
-        env['CXX'] = binaries['CXX']
+        for k,v in binaries.items():
+            env[k] = v
 
     @property
     def configure_option(self):

--- a/kiwixbuild/platforms/armhf.py
+++ b/kiwixbuild/platforms/armhf.py
@@ -69,8 +69,8 @@ class ArmhfPlatformInfo(PlatformInfo):
 
     def set_env(self, env):
         env['PKG_CONFIG_LIBDIR'] = pj(self.root_path, 'lib', 'pkgconfig')
-        env['CFLAGS'] = " -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4 "+env['CFLAGS']
-        env['CXXFLAGS'] = " -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4 "+env['CXXFLAGS']
+        env['CFLAGS'] = " -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4 "+env['CFLAGS']
+        env['CXXFLAGS'] = " -Wp,-D_FORTIFY_SOURCE=2 -fexceptions --param=ssp-buffer-size=4 "+env['CXXFLAGS']
         env['QEMU_LD_PREFIX'] = pj(self.root_path, "arm-linux-gnueabihf", "libc")
         env['QEMU_SET_ENV'] = "LD_LIBRARY_PATH={}".format(
             ':'.join([
@@ -79,8 +79,8 @@ class ArmhfPlatformInfo(PlatformInfo):
         ]))
 
     def set_compiler(self, env):
-        env['CC'] = self.binaries['CC']
-        env['CXX'] = self.binaries['CXX']
+        for k, v in self.binaries.items():
+            env[k] = v
 
     def finalize_setup(self):
         super().finalize_setup()

--- a/kiwixbuild/platforms/ios.py
+++ b/kiwixbuild/platforms/ios.py
@@ -71,8 +71,8 @@ class iOSPlatformInfo(PlatformInfo):
         return '--host={}'.format(self.arch_full)
 
     def set_compiler(self, env):
-        env['CC'] = self.binaries['CC']
-        env['CXX'] = self.binaries['CXX']
+        for k,v in self.binaries.items():
+            env[k] = v
 
 
 class iOSArmv7(iOSPlatformInfo):

--- a/kiwixbuild/templates/meson_cross_file.txt
+++ b/kiwixbuild/templates/meson_cross_file.txt
@@ -4,6 +4,7 @@ c = '{binaries[CC]}'
 ar = '{binaries[AR]}'
 cpp = '{binaries[CXX]}'
 strip = '{binaries[STRIP]}'
+ranlib = '{binaries[RANLIB]}'
 {exec_wrapper_def}
 
 [properties]

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -35,7 +35,7 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = '16'
+base_deps_meta_version = '17'
 
 
 base_deps_versions = {

--- a/travis/compile_all.py
+++ b/travis/compile_all.py
@@ -196,6 +196,7 @@ def make_deps_archive(target, full=False):
         TRAVIS_OS_NAME, PLATFORM, target)
     print_message("Create archive {}.", archive_name)
     files_to_archive = [INSTALL_DIR]
+    files_to_archive += HOME.glob('BUILD_*/LOGS')
     if PLATFORM == 'native_mixed':
         files_to_archive += [HOME/'BUILD_native_static'/'INSTALL']
     if PLATFORM.startswith('android'):


### PR DESCRIPTION
- Dependency are installed "striped".
- Our project are build "debugoptimized" by default and "release" when
  building release instead of "debug"

We need to update the `base_deps_meta_version` as we are changing how
dependencies are compiled.