### PR TITLE
Fix creation of appimage.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,6 @@ addons:
       - ctpp2-utils
       - libmagic-dev
 matrix:
-  allow_failures:
-    - env: PLATFORM="native_dyn" DESKTOP_ONLY=1
   include:
     - env: PLATFORM="native_dyn" DESKTOP_ONLY=1
       addons:

--- a/scripts/create_kiwix-desktop_appImage.sh
+++ b/scripts/create_kiwix-desktop_appImage.sh
@@ -40,4 +40,4 @@ chmod a+x linuxdeployqt-continuous-x86_64.AppImage
 # Fix the RPATH of QtWebEngineProcess [TODO] Fill a issue ?
 patchelf --set-rpath '$ORIGIN/../lib' $APPDIR/usr/libexec/QtWebEngineProcess
 # Build the image.
-./linuxdeployqt-continuous-x86_64.AppImage $APPDIR/usr/share/applications/kiwix-desktop.desktop -verbose=3 -bundle-non-qt-libs -extra-plugins=imageformats,iconengines -appimage
+./linuxdeployqt-continuous-x86_64.AppImage $APPDIR/usr/share/applications/kiwix-desktop.desktop -verbose=3 -unsupported-allow-new-glibc  -bundle-non-qt-libs -extra-plugins=imageformats,iconengines -appimage


### PR DESCRIPTION
Now that issue probonopd/linuxdeployqt#340 is fixed with a new option
`-unsupported-allow-new-glibc`, we can revert commit 4329629f