### PR TITLE
fix unordered flatpak's manifest

### DIFF
--- a/kiwixbuild/flatpak_builder.py
+++ b/kiwixbuild/flatpak_builder.py
@@ -134,7 +134,7 @@ class FlatpakBuilder:
 
     def configure(self):
         steps = remove_duplicates(target_steps())
-        modules = {}
+        modules = OrderedDict()
         for stepDef in steps:
             module = modules.setdefault(stepDef[1], {})
             module['name'] = stepDef[1]


### PR DESCRIPTION
dictionnaries aren't ordered with python 3.5, OrderDict() fixes that.