### PR TITLE
Move from artful to bionic.

### DIFF
--- a/travis/appimage_builder.dockerfile
+++ b/travis/appimage_builder.dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:artful
+FROM ubuntu:bionic
 
 ENV LANG C.UTF-8
 


### PR DESCRIPTION
EOL for artful is july 2018.
It seems that now, apt repository has been shutdown for artful.
It is time to move to a more recent ubuntu version.

Bionic is the oldest release for which QtWebEngine has been packaged.