### PR TITLE
Make the appimage creation less verbose.

### DIFF
--- a/scripts/create_kiwix-desktop_appImage.sh
+++ b/scripts/create_kiwix-desktop_appImage.sh
@@ -36,8 +36,8 @@ wget https://github.com/probonopd/linuxdeployqt/releases/download/continuous/lin
 chmod a+x linuxdeployqt-continuous-x86_64.AppImage
 
 # Fill with all deps libs and so
-./linuxdeployqt-continuous-x86_64.AppImage $APPDIR/usr/bin/kiwix-desktop -verbose=3 -unsupported-allow-new-glibc -bundle-non-qt-libs -extra-plugins=imageformats,iconengines
+./linuxdeployqt-continuous-x86_64.AppImage $APPDIR/usr/bin/kiwix-desktop -unsupported-allow-new-glibc -bundle-non-qt-libs -extra-plugins=imageformats,iconengines
 # Fix the RPATH of QtWebEngineProcess [TODO] Fill a issue ?
 patchelf --set-rpath '$ORIGIN/../lib' $APPDIR/usr/libexec/QtWebEngineProcess
 # Build the image.
-./linuxdeployqt-continuous-x86_64.AppImage $APPDIR/usr/share/applications/kiwix-desktop.desktop -verbose=3 -unsupported-allow-new-glibc -bundle-non-qt-libs -extra-plugins=imageformats,iconengines -appimage
+./linuxdeployqt-continuous-x86_64.AppImage $APPDIR/usr/share/applications/kiwix-desktop.desktop -unsupported-allow-new-glibc -bundle-non-qt-libs -extra-plugins=imageformats,iconengines -appimage


### PR DESCRIPTION
`verbose=3` is too verbose for travis. Travis kill our job because the log
is too long.