### PR TITLE
New android

### DIFF
--- a/kiwixbuild/dependencies/android_ndk.py
+++ b/kiwixbuild/dependencies/android_ndk.py
@@ -1,6 +1,6 @@
 import os
 
-from .base import Dependency, ReleaseDownload, Builder
+from .base import Dependency, ReleaseDownload, NoopBuilder
 from kiwixbuild.utils import Remotefile, add_execution_right, run_command
 
 pj = os.path.join
@@ -11,67 +11,11 @@ class android_ndk(Dependency):
     gccver = '4.9.x'
 
     class Source(ReleaseDownload):
-        archive = Remotefile('android-ndk-r13b-linux-x86_64.zip',
-                             '3524d7f8fca6dc0d8e7073a7ab7f76888780a22841a6641927123146c3ffd29c',
-                             'https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip')
-
+        archive = Remotefile('android-ndk-r19c-linux-x86_64.zip',
+                             '4c62514ec9c2309315fd84da6d52465651cdb68605058f231f1e480fcf2692e1',
+                             'https://dl.google.com/android/repository/android-ndk-r19c-linux-x86_64.zip')
         @property
         def source_dir(self):
             return self.target.full_name()
 
-
-    class Builder(Builder):
-        @property
-        def install_path(self):
-            return self.build_path
-
-        @property
-        def api(self):
-            return '21' if self.arch in ('arm64', 'mips64', 'x86_64') else '14'
-
-        @property
-        def platform(self):
-            return 'android-'+self.api
-
-        @property
-        def arch(self):
-            return self.buildEnv.platformInfo.arch
-
-        @property
-        def arch_full(self):
-            return self.buildEnv.platformInfo.arch_full
-
-        def _build_platform(self, context):
-            context.try_skip(self.build_path)
-            script = pj(self.source_path, 'build/tools/make_standalone_toolchain.py')
-            add_execution_right(script)
-            command = '{script} --arch={arch} --api={api} --install-dir={install_dir} --force'
-            command = command.format(
-                script=script,
-                arch=self.arch,
-                api=self.api,
-                install_dir=self.install_path
-            )
-            context.force_native_build = True
-            run_command(command, self.build_path, context, buildEnv=self.buildEnv)
-
-        def _fix_permission_right(self, context):
-            context.try_skip(self.build_path)
-            bin_dirs = [pj(self.install_path, 'bin'),
-                        pj(self.install_path, self.arch_full, 'bin'),
-                        pj(self.install_path, 'libexec', 'gcc', self.arch_full, self.target.gccver)
-                       ]
-            for root, dirs, files in os.walk(self.install_path):
-                if not root in bin_dirs:
-                    continue
-
-                for file_ in files:
-                    file_path = pj(root, file_)
-                    if os.path.islink(file_path):
-                        continue
-                    add_execution_right(file_path)
-
-        def build(self):
-            self.command('build_platform', self._build_platform)
-            self.command('fix_permission_right', self._fix_permission_right)
-
+    Builder = NoopBuilder

--- a/kiwixbuild/dependencies/xapian.py
+++ b/kiwixbuild/dependencies/xapian.py
@@ -16,7 +16,8 @@ class Xapian(Dependency):
                              '68669327e08544ac88fe3473745dbcae4e8e98d5060b436c4d566f1f78709bb8')
         patches = [
             'xapian_sys_types.patch',
-            'xapian_fix_include_errno.patch'
+            'xapian_fix_include_errno.patch',
+            'xapian_configure.patch'
         ]
 
     class Builder(MakeBuilder):

--- a/kiwixbuild/patches/xapian_configure.patch
+++ b/kiwixbuild/patches/xapian_configure.patch
@@ -1,0 +1,21 @@
+diff -ur xapian-core-1.4.10.orig/configure xapian-core-1.4.10/configure
+--- xapian-core-1.4.10.orig/configure	2019-02-11 22:28:09.000000000 +0100
++++ xapian-core-1.4.10/configure	2019-05-29 17:05:52.900922719 +0200
+@@ -18180,14 +18180,14 @@
+ /* end confdefs.h.  */
+ short int ascii_mm[] =
+ 		  { 0x4249, 0x4765, 0x6E44, 0x6961, 0x6E53, 0x7953, 0 };
+-		short int ascii_ii[] =
++		unsigned short int ascii_ii[] =
+ 		  { 0x694C, 0x5454, 0x656C, 0x6E45, 0x6944, 0x6E61, 0 };
+ 		int use_ascii (int i) {
+ 		  return ascii_mm[i] + ascii_ii[i];
+ 		}
+-		short int ebcdic_ii[] =
++		unsigned short int ebcdic_ii[] =
+ 		  { 0x89D3, 0xE3E3, 0x8593, 0x95C5, 0x89C4, 0x9581, 0 };
+-		short int ebcdic_mm[] =
++		unsigned short int ebcdic_mm[] =
+ 		  { 0xC2C9, 0xC785, 0x95C4, 0x8981, 0x95E2, 0xA8E2, 0 };
+ 		int use_ebcdic (int i) {
+ 		  return ebcdic_mm[i] + ebcdic_ii[i];

--- a/kiwixbuild/platforms/android.py
+++ b/kiwixbuild/platforms/android.py
@@ -8,7 +8,6 @@ class AndroidPlatformInfo(PlatformInfo):
     static = True
     toolchain_names = ['android-ndk']
     compatible_hosts = ['fedora', 'debian']
-    api = "24"
 
     def __str__(self):
         return "android"
@@ -62,8 +61,8 @@ class AndroidPlatformInfo(PlatformInfo):
     def set_env(self, env):
         root_path = pj(self.install_path, 'sysroot')
         env['PKG_CONFIG_LIBDIR'] = pj(root_path, 'lib', 'pkgconfig')
-        env['CFLAGS'] = '-fPIC -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64 --sysroot={} '.format(root_path) + env['CFLAGS']
-        env['CXXFLAGS'] = '-fPIC -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64 --sysroot={} '.format(root_path) + env['CXXFLAGS']
+        env['CFLAGS'] = '-fPIC --sysroot={} '.format(root_path) + env['CFLAGS']
+        env['CXXFLAGS'] = '-fPIC --sysroot={} '.format(root_path) + env['CXXFLAGS']
         env['LDFLAGS'] = '--sysroot={} '.format(root_path) + env['LDFLAGS']
         #env['CFLAGS'] = ' -fPIC -D_FILE_OFFSET_BITS=64 -O3 '+env['CFLAGS']
         #env['CXXFLAGS'] = (' -D__OPTIMIZE__ -fno-strict-aliasing '
@@ -92,6 +91,7 @@ class AndroidArm(AndroidPlatformInfo):
     arch = cpu = 'arm'
     arch_full = 'armv7a-linux-androideabi'
     abi = 'armeabi-v7a'
+    api = '24'
 
     @property
     def binaries_name(self):
@@ -107,6 +107,7 @@ class AndroidArm64(AndroidPlatformInfo):
     arch_full = 'aarch64-linux-android'
     cpu = 'aarch64'
     abi = 'arm64-v8a'
+    api = '21'
 
 
 class AndroidX86(AndroidPlatformInfo):
@@ -114,12 +115,14 @@ class AndroidX86(AndroidPlatformInfo):
     arch = abi = 'x86'
     arch_full = 'i686-linux-android'
     cpu = 'i686'
+    api = '24'
 
 
 class AndroidX8664(AndroidPlatformInfo):
     name = 'android_x86_64'
     arch = cpu = abi = 'x86_64'
     arch_full = 'x86_64-linux-android'
+    api = '21'
 
 
 class Android(MetaPlatformInfo):

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -35,7 +35,7 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = '51'
+base_deps_meta_version = '52'
 
 
 base_deps_versions = {
@@ -52,7 +52,7 @@ base_deps_versions = {
   'libaria2' : '1.33.1',
   'libmagic' : '5.35',
   'android-sdk' : 'r26.1.1',
-  'android-ndk' : 'r13b',
+  'android-ndk' : 'r19c',
   'qt' : '5.10.1',
   'qtwebengine' : '5.10.1',
   'org.kde' : '5.12',


### PR DESCRIPTION
This PR move to the last version of the ndk and build android only :

- armeabi-v7a
- arm64-v8a
- x86
- x86_64

See https://github.com/kiwix/kiwix-lib/issues/224

However, 32 bits arch (`armeabi-v7a` and `x86`) move from api 14 to 24.

According to https://android-developers.googleblog.com/2017/09/introducing-android-native-development.html, setting _FILE_OFFSET_BITS was doing nothing on old ndk version <=15, so native code was using 32bits offsets and so cannot move to offset bigger that 2Go.
With recent ndk version >15, _FILE_OFFSET_BITS now export the symbol for which 64bits offsets is available, if not, the symbol is not exported.
However, we need to move to api 24 to have all the symbol we need being exported.

I don't know how many user we lost by moving our 32bits apk from api 14 to api 24.
But, in the same time, 32 bits users probably have buggy applications for reading zim > 2Go.

cc @macgills @kelson42 
