### PR TITLE
update android sdk tools to 26.1.1

### DIFF
--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -51,7 +51,7 @@ base_deps_versions = {
   'gradle' : '5.1.1',
   'libaria2' : '1.33.1',
   'libmagic' : '5.35',
-  'android-sdk' : 'r25.2.3',
+  'android-sdk' : 'r26.1.1',
   'android-ndk' : 'r13b',
   'qt' : '5.10.1',
   'qtwebengine' : '5.10.1',


### PR DESCRIPTION
update to sdk tools used in newest android studio 3.4.1 and gradle build tools