### PR TITLE
fix for macOS cross build targeting iOS

### DIFF
--- a/kiwixbuild/platforms/ios.py
+++ b/kiwixbuild/platforms/ios.py
@@ -50,7 +50,7 @@ class iOSPlatformInfo(PlatformInfo):
         env['CFLAGS'] = " -fembed-bitcode -isysroot {SDKROOT} -arch {arch} -miphoneos-version-min=9.0 ".format(SDKROOT=self.root_path, arch=self.arch) + env['CFLAGS']
         env['CXXFLAGS'] = env['CFLAGS'] + " -stdlib=libc++ -std=c++11 "+env['CXXFLAGS']
         env['LDFLAGS'] = " -arch {arch} -isysroot {SDKROOT} ".format(SDKROOT=self.root_path, arch=self.arch)
-        env['MACOSX_DEPLOYMENT_TARGET'] = "10.7"
+        env['MACOSX_DEPLOYMENT_TARGET'] = "10.10"
 
     def get_bin_dir(self):
         return [pj(self.root_path, 'bin')]


### PR DESCRIPTION
Fix #323

Looks like this is the only line I need to change to make targeting iOS compile work on macOS 10.14. 
I do however have to do what this ticket said to get curl working: https://github.com/curl/curl/issues/3189

Speaking of curl. Why does libkiwix need curl? Kinda ironic considering what libkiwix does is offline viewing...