### PR TITLE
Generate the AppImage on xenial distribution.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,16 @@ script:
       --mount=type=bind,src=$HOME/.gradle/caches,dst=/home/ci_builder/.gradle/caches \
       --mount=type=bind,src=$TRAVIS_BUILD_DIR,dst=/home/ci_builder/kiwix-build \
       kiwix/kiwix-build_ci:${VARIANT}-${DOCKER_VERSION}
+    if [[ $PLATFORM = "native_dyn" && $DESKTOP_ONLY = 1 ]]
+    then
+      docker run -rm \
+      -e PLATFORM -e NIGHTLY_DATE -e TRAVIS_EVENT_TYPE -e DESKTOP_ONLY -e TRAVIS_TAG \
+      --device /dev/fuse --cap-add ALL --privileged \
+      --mount=type=bind,src=$HOME/EXPORT,dst=/home/ci_builder/EXPORT \
+      --mount=type=bind,src=$TRAVIS_BUILD_DIR,dst=/home/ci_builder/kiwix-build \
+      kiwix/kiwix-build_ci:xenial-${DOCKER_VERSION} \
+      /home/ci_builder/kiwix-build/scripts/create_kiwix-desktop_appImage.sh /home/ci_builder/EXPORT/AppDir
+    fi
   fi
 - if [[ $TRAVIS_OS_NAME != "linux" ]]; then python3 travis/compile_all.py; fi
 after_success:
@@ -110,7 +120,7 @@ env:
   global:
     - NIGHTLY_DATE=$(date +%Y-%m-%d)
     - SSH_KEY=/tmp/private/travisci_builder_id_key
-    - DOCKER_VERSION=2
+    - DOCKER_VERSION=3
   matrix:
     - PLATFORM="flatpak" DESKTOP_ONLY=1
     - PLATFORM="native_dyn"

--- a/scripts/create_kiwix-desktop_appImage.sh
+++ b/scripts/create_kiwix-desktop_appImage.sh
@@ -2,50 +2,19 @@
 
 set -e
 
-INSTALLDIR=${1:-$PWD/BUILD_native_dyn/INSTALL}
-SOURCEDIR=${2:-$PWD/SOURCE/kiwix-desktop}
-APPDIR=${3:-$PWD/AppDir}
-
-SYSTEMLIBDIR=lib/x86_64-linux-gnu
-# Uncoment if needed
-#SYSTEMLIBDIR=lib64
-
-#TODO We should have our icon
-ICONFILE=$SOURCEDIR/resources/icons/kiwix/app_icon.svg
-DESKTOPFILE=$SOURCEDIR/resources/org.kiwix.desktop.desktop
-
-# Create structure
-mkdir -p $APPDIR/usr/{bin,lib,share} $APPDIR/usr/share/applications $APPDIR/usr/share/icons/hicolor/48x48/apps
-# Copy our files
-cp $INSTALLDIR/bin/kiwix-desktop $APPDIR/usr/bin/
-cp $INSTALLDIR/$SYSTEMLIBDIR/*.so* $APPDIR/usr/lib
-# Remove it as it break with linuxdeployqt (should we compile without it) ?
-rm $APPDIR/usr/lib/libmagic.so*
-# Copy nss lib (to not conflict with host's ones)
-cp -a /usr/$SYSTEMLIBDIR/nss $APPDIR/usr/lib
-cp -a /usr/$SYSTEMLIBDIR/libstdc++.so* $APPDIR/usr/lib
-cp -a /usr/$SYSTEMLIBDIR/libc.so* $APPDIR/usr/lib
-cp -a /usr/$SYSTEMLIBDIR/libz.so* $APPDIR/usr/lib
-cp $ICONFILE $APPDIR/usr/share/icons/hicolor/48x48/apps/kiwix-desktop.svg
-mkdir -p $APPDIR/usr/share/applications
-cp $DESKTOPFILE $APPDIR/usr/share/applications/kiwix-desktop.desktop
-
-# get the aria2
-wget https://github.com/q3aql/aria2-static-builds/releases/download/v1.34.0/aria2-1.34.0-linux-gnu-64bit-build1.tar.bz2
-mkdir -p $APPDIR/usr/bin/ && tar -C $APPDIR/usr/bin/ -xf aria2-1.34.0-linux-gnu-64bit-build1.tar.bz2 aria2-1.34.0-linux-gnu-64bit-build1/aria2c --strip-components=1
-mkdir -p $APPDIR/etc/ssl/certs/ && tar -C $APPDIR/etc/ssl/certs/ -xf aria2-1.34.0-linux-gnu-64bit-build1.tar.bz2 aria2-1.34.0-linux-gnu-64bit-build1/ca-certificates.crt --strip-components=1
-
-# copy kiwix-serve
-cp $INSTALLDIR/bin/kiwix-serve $APPDIR/usr/bin
+APPDIR=${1:-$PWD/AppDir}
+APPIMAGETOOL=appimagetool-x86_64.AppImage
+VERSION=$(grep '^VERSION' $APPDIR/info.txt | awk '{print $2}')
+EXPORT_DIR=$(grep '^EXPORT_DIR' $APPDIR/info.txt | awk '{print $2}')
+APP_NAME="kiwix-desktop_x86_64_${VERSION}.appimage"
 
 # Get linuxdeployqt
-wget https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
-chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+if [ ! -x $APPIMAGETOOL ]
+then
+  wget https://github.com/AppImage/AppImageKit/releases/download/12/$APPIMAGETOOL
+  chmod a+x $APPIMAGETOOL
+fi
 
-# Fill with all deps libs and so
-./linuxdeployqt-continuous-x86_64.AppImage $APPDIR/usr/bin/kiwix-desktop -unsupported-allow-new-glibc -bundle-non-qt-libs -extra-plugins=imageformats,iconengines
-# Fix the RPATH of QtWebEngineProcess [TODO] Fill a issue ?
-patchelf --set-rpath '$ORIGIN/../lib' $APPDIR/usr/libexec/QtWebEngineProcess
-patchelf --set-rpath '$ORIGIN/../lib' $APPDIR/usr/bin/kiwix-serve
+echo "Create appimage from $APPDIR to ${EXPORT_DIR}/$APP_NAME"
 # Build the image.
-./linuxdeployqt-continuous-x86_64.AppImage $APPDIR/usr/share/applications/kiwix-desktop.desktop -unsupported-allow-new-glibc -bundle-non-qt-libs -extra-plugins=imageformats,iconengines -appimage
+./$APPIMAGETOOL $APPDIR $EXPORT_DIR/$APP_NAME

--- a/scripts/prepare_kiwix-desktop_appImage.sh
+++ b/scripts/prepare_kiwix-desktop_appImage.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -e
+
+INSTALLDIR=${1:-$PWD/BUILD_native_dyn/INSTALL}
+SOURCEDIR=${2:-$PWD/SOURCE/kiwix-desktop}
+APPDIR=${3:-$HOME/AppDir}
+
+SYSTEMLIBDIR=lib/x86_64-linux-gnu
+# Uncoment if needed
+#SYSTEMLIBDIR=lib64
+
+#TODO We should have our icon
+ICONFILE=$SOURCEDIR/resources/icons/kiwix/app_icon.svg
+DESKTOPFILE=$SOURCEDIR/resources/org.kiwix.desktop.desktop
+
+# Create structure
+mkdir -p $APPDIR/usr/{bin,lib,share} $APPDIR/usr/share/applications $APPDIR/usr/share/icons/hicolor/48x48/apps
+# Copy our files
+cp $INSTALLDIR/bin/kiwix-desktop $APPDIR/usr/bin/
+cp $INSTALLDIR/$SYSTEMLIBDIR/*.so* $APPDIR/usr/lib
+# Remove it as it break with linuxdeployqt (should we compile without it) ?
+rm $APPDIR/usr/lib/libmagic.so*
+# Copy nss lib (to not conflict with host's ones)
+cp -a /usr/$SYSTEMLIBDIR/nss $APPDIR/usr/lib
+cp -a /usr/$SYSTEMLIBDIR/libstdc++.so* $APPDIR/usr/lib
+cp -a /usr/$SYSTEMLIBDIR/libc.so* $APPDIR/usr/lib
+cp -a /usr/$SYSTEMLIBDIR/libz.so* $APPDIR/usr/lib
+cp $ICONFILE $APPDIR/kiwix-desktop.svg
+cp $DESKTOPFILE $APPDIR/kiwix-desktop.desktop
+
+# get the aria2
+wget https://github.com/q3aql/aria2-static-builds/releases/download/v1.34.0/aria2-1.34.0-linux-gnu-64bit-build1.tar.bz2
+mkdir -p $APPDIR/usr/bin/ && tar -C $APPDIR/usr/bin/ -xf aria2-1.34.0-linux-gnu-64bit-build1.tar.bz2 aria2-1.34.0-linux-gnu-64bit-build1/aria2c --strip-components=1
+mkdir -p $APPDIR/etc/ssl/certs/ && tar -C $APPDIR/etc/ssl/certs/ -xf aria2-1.34.0-linux-gnu-64bit-build1.tar.bz2 aria2-1.34.0-linux-gnu-64bit-build1/ca-certificates.crt --strip-components=1
+
+# copy kiwix-serve
+cp $INSTALLDIR/bin/kiwix-serve $APPDIR/usr/bin
+
+# Get linuxdeployqt
+wget https://github.com/probonopd/linuxdeployqt/releases/download/6/linuxdeployqt-6-x86_64.AppImage
+chmod a+x linuxdeployqt-6-x86_64.AppImage
+
+# Fill with all deps libs and so
+./linuxdeployqt-6-x86_64.AppImage $APPDIR/usr/bin/kiwix-desktop -unsupported-allow-new-glibc -bundle-non-qt-libs -extra-plugins=imageformats,iconengines
+# Fix the RPATH of QtWebEngineProcess [TODO] Fill a issue ?
+patchelf --set-rpath '$ORIGIN/../lib' $APPDIR/usr/libexec/QtWebEngineProcess
+patchelf --set-rpath '$ORIGIN/../lib' $APPDIR/usr/bin/kiwix-serve
+
+
+echo "create $APPDIR/AppRun"
+LIBC_BUILD_VERSION=$(ldd --version | head -1 | awk '{ print $NF }')
+rm $APPDIR/AppRun
+cat <<'EOF' | sed "s/__LIBC_BUILD_VERSION__/${LIBC_BUILD_VERSION}/" > $APPDIR/AppRun
+#!/bin/bash
+
+HERE=$(dirname "$(readlink -f "${0}")")
+LIBC_VERSION=$(ldd --version | head -1 | awk '{ print $NF }' )
+LIBC_BUILD_VERSION="__LIBC_BUILD_VERSION__"
+
+function normalize { printf "%03d%03d" $(echo "$1" | tr '.' ' '); }
+
+if [ $(normalize $LIBC_VERSION) -lt $(normalize $LIBC_BUILD_VERSION) ]
+then
+  echo "Your glib version ($LIBC_VERSION) is too old to run kiwix-desktop"
+  echo "You need at least version $LIBC_BUILD_VERSION."
+else
+  exec $HERE/usr/bin/kiwix-desktop
+fi
+EOF
+chmod a+x $APPDIR/AppRun

--- a/travis/bionic_builder.dockerfile
+++ b/travis/bionic_builder.dockerfile
@@ -13,8 +13,6 @@ RUN apt update -q && \
     libmicrohttpd-dev aria2 \
 # Qt packages
     libqt5gui5 qtbase5-dev qtwebengine5-dev libqt5svg5-dev qt5-image-formats-plugins qt5-default \
-# To create the appimage of kiwix-desktop
-    libfuse2 fuse patchelf \
 # Flatpak tools
     elfutils flatpak flatpak-builder \
 # Cross win32 compiler

--- a/travis/compile_all.py
+++ b/travis/compile_all.py
@@ -130,20 +130,19 @@ def create_desktop_image():
         archive_dir = NIGHTLY_KIWIX_ARCHIVES_DIR
         src_dir = SOURCE_DIR/'kiwix-desktop'
 
-    if PLATFORM == 'flatpak':
-        build_path = BASE_DIR/'org.kiwix.desktop.flatpak'
-        app_name = 'org.kiwix.desktop.{}.flatpak'.format(postfix)
-        print_message("archive is ", build_path)
-    else:
-        build_path = HOME/'Kiwix-{}-x86_64.AppImage'.format(postfix)
-        app_name = "kiwix-desktop_x86_64_{}.appimage".format(postfix)
-        command = ['kiwix-build/scripts/create_kiwix-desktop_appImage.sh',
-                   str(INSTALL_DIR), str(src_dir), str(HOME/'AppDir')]
-        env = dict(os.environ)
-        env['VERSION'] = postfix
+    if PLATFORM != 'flatpak':
+        app_dir = EXPORT_DIR/'AppDir'
+        command = ['kiwix-build/scripts/prepare_kiwix-desktop_appImage.sh',
+                   str(INSTALL_DIR), str(src_dir), str(app_dir)]
         print_message("Build AppImage of kiwix-desktop")
-        subprocess.check_call(command, cwd=str(HOME), env=env)
+        subprocess.check_call(command, cwd=str(HOME))
+        with open(str(app_dir/'info.txt'), 'w') as f:
+            f.write("VERSION {}\nEXPORT_DIR {}".format(postfix, archive_dir))
+        return
 
+    build_path = BASE_DIR/'org.kiwix.desktop.flatpak'
+    app_name = 'org.kiwix.desktop.{}.flatpak'.format(postfix)
+    print_message("archive is ", build_path)
     try:
         archive_dir.mkdir(parents=True)
     except FileExistsError:

--- a/travis/xenial_builder.dockerfile
+++ b/travis/xenial_builder.dockerfile
@@ -16,6 +16,8 @@ RUN apt update -q && \
     libmicrohttpd-dev \
 # Cross compile i586
     libc6-dev-i386 lib32stdc++6 gcc-multilib g++-multilib \
+# To create the appimage of kiwix-desktop
+    libfuse2 fuse patchelf \
 # Other tools (to remove)
 #    vim less grep \
   && \


### PR DESCRIPTION
AppImage should be genarated on a "old" distribution to be sure that
libc versions are compatible.

However, we need at least ubuntu bionic to have QWebEngine packaged.
Let's prepare our AppDir directory in bionic and generate the appimage
in xenial.
By using a small launcher script, we check that libc versions are
compatible and else print a nice message instead of crash.

See https://github.com/probonopd/linuxdeployqt/issues/340