### PR TITLE
switch to older version of libmicrohttpd

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -103,7 +103,7 @@ jobs:
       shell: bash
       run: |
         cd $HOME
-        git clone https://github.com/${REP} --depth=1 --branch ${GITHUB_REF##*/}
+        git clone https://github.com/${REP} --depth=1 --branch ${GITHUB_REF##*heads/}
         pip3 install --user --no-deps ./${REP##*/}
       env:
         REP: ${{github.repository}}

--- a/kiwixbuild/dependencies/base.py
+++ b/kiwixbuild/dependencies/base.py
@@ -324,7 +324,7 @@ class MakeBuilder(Builder):
             env['CFLAGS'] = env['CFLAGS'] + ' -fPIC'
             env['CXXFLAGS'] = env['CXXFLAGS'] + ' -fPIC'
         if self.configure_env:
-            for k in self.configure_env:
+            for k in list(self.configure_env):
                 if k.startswith('_format_'):
                     v = self.configure_env.pop(k)
                     v = v.format(buildEnv=self.buildEnv, env=env)

--- a/kiwixbuild/dependencies/libmicrohttpd.py
+++ b/kiwixbuild/dependencies/libmicrohttpd.py
@@ -9,9 +9,9 @@ class MicroHttpd(Dependency):
     name = "libmicrohttpd"
 
     class Source(ReleaseDownload):
-        archive = Remotefile('libmicrohttpd-0.9.69.tar.gz',
-                             'fb9b6b148b787493e637d3083588711e65cbcb726fa02cee2cd543c5de27e37e',
-                             'https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.69.tar.gz')
+        archive = Remotefile('libmicrohttpd-0.9.63.tar.gz',
+                             '37c36f1be177f0e37ef181a645cd3baac1000bd322a01c2eff70f3cc8c91749c',
+                             'https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-0.9.63.tar.gz')
 
     class Builder(MakeBuilder):
         configure_option = "--disable-https --without-libgcrypt --without-libcurl --disable-doc --disable-examples"

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -42,7 +42,7 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = '59'
+base_deps_meta_version = '60'
 
 base_deps_versions = {
   'zlib' : '1.2.8',
@@ -51,7 +51,7 @@ base_deps_versions = {
   'xapian-core' : '1.4.14',
   'mustache' : '3.2',
   'pugixml' : '1.2',
-  'libmicrohttpd' : '0.9.69',
+  'libmicrohttpd' : '0.9.63',
   'gumbo' : '0.10.1',
   'icu4c' : '58.2',
   'libaria2' : '1.33.1',


### PR DESCRIPTION
there's a weird bug on macOS (catalina as least) with version `0.9.69` of `libmicrohttpd`.

It compiles and links properly but the server can never be started, failing in `MHD_start_daemon`: it always returns false and when enabling debug, the message simply says `Failed to create socket for listening`. Depending on version, details are either `file not found` or `undefined: 0`.

I tested many different combinations of versions and compile flags but ultimately settled with just using older version `0.9.63`. I haven't tested on other platforms but hope it can be replaced as is.

Here's the changelog in-between:

```
Sun 15 Dec 2019 02:12:02 PM CET
    Fix send() call (affects Mac OS X). #5977 -CG/fbrault
    Releasing libmicrohttpd 0.9.69. -CG

Fri 29 Nov 2019 11:22:25 PM CET
    If application suspends a connection before we could send 100 CONTINUE,
    give application another shot at queuing a reply before the upload begins. -CG

Sat 26 Oct 2019 06:53:05 PM CEST
    Fix regression where MHD would fail to return an empty response
    when used with HTTPS.
    Releasing libmicrohttpd 0.9.68. -CG/TR

Fri 25 Oct 2019 02:31:59 PM CEST
    Introduce MHD_RF_INSANITY_HEADER_CONTENT_LENGTH. -CG

Thu 17 Oct 2019 04:50:52 PM CEST
    Integrate 0-byte send() method for uncorking for old FreeBSD/OS X
    systems into new mhd_send.c logic for uncorking.
    Releasing libmicrohttpd 0.9.67. -CG

Fri 18 Aug 2019 00:00:00 PM UTC
    Fixes and optimizations for the setsockopt handling:
    * Added: MHD_UPGRADE_ACTION_CORK_ON and MHD_UPGRADE_ACTION_CORK_OFF
      to enum MHD_UpgradeAction (turn corking on/off on the underlying
      socket).
    * Use calls and flags native to the system for corking and
      other operations, tested with performance improvements on
      FreeBSD, Debian Linux, NetBSD, and cygwin. In particular,
      this adds selective usage of MSG_MORE, NODELAY, TCP_NOPUSH,
      TCP_CORK. -ng0

Fri 09 Aug 2019 10:07:27 AM CEST
    Copy compiler and linker hardening flags from GNUnet (updating
    configure.ac). -CG

Thu 01 Aug 2019 01:23:36 PM CEST
    Releasing libmicrohttpd 0.9.66. -CG

Thu 01 Aug 2019 12:53:49 AM CEST
    Fix issue with discarding unhandled upload data discovered
    by Florian Dold. -CG

Mon 29 Jul 2019 08:01:50 PM CEST
    Fix hanging situation with large transmission over upgraded
    (i.e. Web socket) connection with epoll() and HTTPS enabled
    (as reported by Viet on the mailinglist). -CG

Thu 25 Jul 2019 02:40:12 PM CEST
    Fixing regression introduced in cc5032b85 (bit mask matching
    of the header kinds in MHD_lookup_connection_value()), as
    reported by Jose Bollo on the mailinglist. -CG/JB

Tue Jul 16 19:56:14 CEST 2019
    Add MHD_OPTION_HTTPS_CERT_CALLBACK2 to allow OCSP stapling
    and MHD_FEATURE_HTTPS_CERT_CALLBACK2 to check for. -TR

Fri Jul 05 2019 22:30:40 MSK
	Releasing libmicrohttpd 0.9.65. -EG

Sun Jun 23 2019 21:27:43 MSK
	Many fixes and improvements for connection-specific memory pool:
	* Added asserts;
	* Added testing of reallocation;
	* Reallocation code rewritten to avoid extra allocation, when
	  possible to reuse already allocated memory;
	* Large memory pools aligned to system page size;
	* Large memory pools on W32 are cleared more securely after use,
	  optimised usage of system memory.
	Better handled connection's memory shortage situations:
	* error response could be sent to client even if all buffer space
	  was used;
	* if buffer space become low when receiving, do not allocate last
	  buffer space and use small receive blocks instead.
	Improved sending speed by using all available buffer space for
	sending. -EG

Sun Jun 09 2019 20:27:04 MSK
	Releasing libmicrohttpd 0.9.64. -EG

Sun Jun 09 2019 20:03:16 MSK
	Updated HTTP headers, methods and status codes from registries,
	Added scripts to import new headers, methods and status codes from
	registries,
	Minor doxyget comment fix,
	Added missing MSVS project files to tarball.
	Reodered includes in microhttpd.h -EG

Mon 03 Jun 2019 11:45:52 PM CEST
	Apply MHD_-prefix to hash functions, even if they are not in the
	officially exported API. -CG/DB

Sun Jun 02 01:52:11 MSK 2019
	Support usage of SOCK_NOSIGPIPE on Solaris 11.4 and NetBSD 7+,
	finally avoid SIGPIPE on Solaris. -EG

Sat Jun 01 22:51:50 MSK 2019
	Do not report errors if AF_UNIX socket is used on *BSD. -EG

Thu May 30 23:32:09 MSK 2019
	Improved detection of 'getsockname()' in configure.
	Avoided using 'getsockname()' in code if not detected. -EG

Sun May 26 23:32:49 MSK 2019
	Fixed some tests on W32. -EG

Sun May 26 23:05:42 MSK 2019
	Better detection of sockaddr member in configure, fixed build on *BSD,
	Fixed compiler warnings,
	Updated and fixed libcurl tests. -EG

Tue May 21 22:12:43 MSK 2019
	Fixed doxygen comments,
	Avoid dropping 'const' qualifier in macros,
	Fixed some compiler warnings,
	Properly support automatic port detections on some platforms,
	Added checks for too long TLS parameters strings. -EG

Tue May 21 17:52:48 MSK 2019
	Spelling fixes. -EG

Mon May 20 15:39:35 MSK 2019
	Compiler warning fixes. -EG/CG
	Fixed example for non-64bits platforms. -EG

Web May 15 23:51:49 MSK 2019
	Optimized and improved processing speed by using precalculated and
	already calculated lengths of strings. -EG

Web May 15 14:54:00 MSK 2019
	Fixed build from source on GNU Hurd. -EG

Mon May  6 11:58:00 MSK 2019
	Updated README and COPYING files. MHD remains LGPLv2.1-licensed. -EG

Fri May  3 20:08:00 MSK 2019
	Store connection's keys and values with sizes;
	Speedup keys search be comparing key length first;
	Added functions for working with keys and values with binary zeros;
	Fixed test_postprocessor_amp to fail on problems. -EG

Wed May  1 16:40:00 MSK 2019
	Reverted change of MHD_KeyValueIterator, implemented MHD_KeyValueIteratorN
	with sizes for connection's key and value to get keys and values
	with binary zeros. -EG

Mon 29 Apr 2019 01:26:39 AM BRT
	Fixed signed/unsigned comparison in example http_chunked_compression.c. -SC/TR

Sun Apr 21 16:40:00 MSK 2019
	Improved compatibility with MSVC compilers;
	Fixed MHD compilation by Clang/LLVM in VS;
	Used MSVC intrinsics for bit rotations and bytes swap;
	Added project files for VS2019. -EG

Fri Apr 19 23:00:00 MSK 2019
	Rewritten SHA-256 calculations from scratch to avoid changing LGPL version;
	Added usage of GCC/Clang built-ins for bytes swap to significantly improve
	speed of MD5 and SHA-256 calculation on platforms with known endianness.
	Added test for SHA-256 calculations. -EG

Wed Apr 17 20:52:00 MSK 2019
	Refactoring of mhd5.c: optimized, dead code removed;
	Faster MD5 calculation on little endian platforms;
	Bit manipulations moved to separate header file.
	Added tests for MD5 calculations. -EG

Mon 15 Apr 2019 05:33:52 PM CEST
	Add MHD_USE_POST_HANDSHAKE_AUTH_SUPPORT and
	MHD_USE_INSECURE_TLS_EARLY_DATA flags. -CG

Thu Apr 11 11:37:00 MSK 2019
	Fixed MSVC 'Release' builds;
	Fixed usage of MSVC's assert. -EG

Wed Apr 10 14:31:00 MSK 2019
	Improved shell compatibility for 'bootstrap', removed bash-ism.
	Added wrapper script 'autogen.sh'. -EG

Mon 08 Apr 2019 03:06:05 PM CEST
	Fix close() checks as suggested by MK on the mailinglist
        (#3926). -MK/CG

Wed 20 Mar 2019 10:20:24 AM CET
	Adding additional "value_length" argument to MHD_KeyValueIterator
	callback to support binary zeros in values.  This is done in a
	backwards-compatible way, but may require adding a cast to existing
	code to avoid a compiler warning. -CG

Sun Feb 10 21:00:37 BRT 2019
	Added example for how to compress a chunked HTTP response. -SC

Sun 10 Feb 2019 05:03:44 PM CET
	Releasing libmicrohttpd 0.9.63. -CG
```

I've also tested newest version `0.9.70` but it's no working either. Here's its changelog

```
Sat 08 Feb 2020 09:12:54 PM CET
    Fixed 100-continue handling for PATCH method (#6068).
    Fixed FTBFS from wrong #endif position for certain builds (#6025).
    Fixed connection overflow issue when combining MHD_USE_NO_LISTEN_SOCKET
    with MHD_USE_THREAD_PER_CONNECTION (#6036).
    Updated m4 script to fix FTBFS when using -Werror=unused-but-set-parameter (#6078).
    Releasing libmicrohttpd 0.9.70. -CG

Thu Dec 26 14:43:27 CET 2019
    Adding fix for urlencoding of keys without values in
    post-processor logic. -CG

Tue 24 Dec 2019 03:32:18 PM CET
    Adding patch from Ethan Tuttle with test case for urlencoding
    in post-processor for keys without values. -CG/ET
```

Oh and the problem happens similarly inside kiwix-tools (server) and the bundled examples.

Also included in this PR (should be separate I agree, feel free to apply independently), is a quick-fix to a crash due to dictionary changing during iteration on python3.8 ([bpo-36452](https://bugs.python.org/issue36452))