### PR TITLE
Always write the cross_file using the same name.

### DIFF
--- a/kiwixbuild/platforms/android.py
+++ b/kiwixbuild/platforms/android.py
@@ -87,7 +87,7 @@ class AndroidPlatformInfo(PlatformInfo):
 
     def finalize_setup(self):
         super().finalize_setup()
-        self.buildEnv.cmake_crossfile = self._gen_crossfile('cmake_android_cross_file.txt')
+        self.buildEnv.cmake_crossfile = self._gen_crossfile('cmake_android_cross_file.txt', 'cmake_cross_file.txt')
         self.buildEnv.meson_crossfile = self._gen_crossfile('meson_cross_file.txt')
 
 

--- a/kiwixbuild/platforms/base.py
+++ b/kiwixbuild/platforms/base.py
@@ -94,8 +94,10 @@ class PlatformInfo(metaclass=_MetaPlatform):
             env['CXXFLAGS'] = env['CXXFLAGS'] + ' -fPIC'
 
 
-    def _gen_crossfile(self, name):
-        crossfile = pj(self.buildEnv.build_dir, name)
+    def _gen_crossfile(self, name, outname=None):
+        if outname is None:
+            outname = name
+        crossfile = pj(self.buildEnv.build_dir, outname)
         template_file = pj(TEMPLATES_DIR, name)
         with open(template_file, 'r') as f:
             template = f.read()

--- a/kiwixbuild/platforms/i586.py
+++ b/kiwixbuild/platforms/i586.py
@@ -53,7 +53,7 @@ class I586PlatformInfo(PlatformInfo):
 
     def finalize_setup(self):
         super().finalize_setup()
-        self.buildEnv.cmake_crossfile = self._gen_crossfile('cmake_i586_cross_file.txt')
+        self.buildEnv.cmake_crossfile = self._gen_crossfile('cmake_i586_cross_file.txt', 'cmake_cross_file.txt')
         self.buildEnv.meson_crossfile = self._gen_crossfile('meson_cross_file.txt')
 
 class I586Dyn(I586PlatformInfo):

--- a/kiwixbuild/platforms/ios.py
+++ b/kiwixbuild/platforms/ios.py
@@ -27,8 +27,8 @@ class iOSPlatformInfo(PlatformInfo):
 
     def finalize_setup(self):
         super().finalize_setup()
-        self.buildEnv.cmake_crossfile = self._gen_crossfile('cmake_ios_cross_file.txt')
-        self.buildEnv.meson_crossfile = self._gen_crossfile('meson_ios_cross_file.txt')
+        self.buildEnv.cmake_crossfile = self._gen_crossfile('cmake_ios_cross_file.txt', 'cmake_cross_file.txt')
+        self.buildEnv.meson_crossfile = self._gen_crossfile('meson_ios_cross_file.txt', 'meson_cross_file.txt')
 
     def get_cross_config(self):
         return {


### PR DESCRIPTION
Even if we use different template for different platform, we must
always use the same cross_file name.