### PR TITLE
Build all make based dependency using -O3 option.

### DIFF
--- a/kiwixbuild/dependencies/base.py
+++ b/kiwixbuild/dependencies/base.py
@@ -303,7 +303,10 @@ class MakeBuilder(Builder):
     make_option = ""
     install_option = ""
     configure_script = "configure"
-    configure_env = None
+    configure_env = {
+        '_format_CFLAGS' : '{env[CFLAGS]} -O3',
+        '_format_CXXFLAGS': '{env[CXXFLAGS]} -O3'
+    }
     make_target = ""
     flatpak_buildsystem = None
 

--- a/kiwixbuild/dependencies/kiwix_desktop.py
+++ b/kiwixbuild/dependencies/kiwix_desktop.py
@@ -13,6 +13,7 @@ class KiwixDesktop(Dependency):
     class Builder(QMakeBuilder):
         dependencies = ["qt", "qtwebengine", "kiwix-lib", "aria2", "kiwix-tools"]
         make_install_target = 'install'
+        configure_env = None
 
         @property
         def configure_option(self):

--- a/kiwixbuild/dependencies/uuid.py
+++ b/kiwixbuild/dependencies/uuid.py
@@ -19,7 +19,7 @@ class UUID(Dependency):
     class Builder(MakeBuilder):
         configure_option = ("--enable-libuuid --disable-debugfs --disable-imager --disable-resizer --disable-defrag --enable-fsck"
                             " --disable-uuidd")
-        configure_env = {'_format_CFLAGS': "{env.CFLAGS} -fPIC"}
+        configure_env = {'_format_CFLAGS': "{env.CFLAGS} -O3 -fPIC"}
         static_configure_option = dynamic_configure_option = ""
         make_target = 'libs'
         make_install_target = 'install-libs'

--- a/kiwixbuild/dependencies/xapian.py
+++ b/kiwixbuild/dependencies/xapian.py
@@ -23,7 +23,7 @@ class Xapian(Dependency):
     class Builder(MakeBuilder):
         configure_option = "--disable-sse --disable-backend-chert --disable-backend-remote --disable-backend-inmemory --disable-documentation"
         configure_env = {'_format_LDFLAGS': "{env.LDFLAGS} -L{buildEnv.install_dir}/{buildEnv.libprefix}",
-                         '_format_CXXFLAGS': "{env.CXXFLAGS} -I{buildEnv.install_dir}/include"}
+                         '_format_CXXFLAGS': "{env.CXXFLAGS} -O3 -I{buildEnv.install_dir}/include"}
 
 
         @classmethod

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -42,7 +42,7 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = '63'
+base_deps_meta_version = '64'
 
 base_deps_versions = {
   'zlib' : '1.2.8',


### PR DESCRIPTION
This will build all Make, CMake, QMake dependency being build with -O3.
So all our dependencies will be build with -O3.

Our project (meson) are already build in release when needed.
kiwix-desktop should be build optimized in case of release but we need
to handle it correctly. At least not build in O3 per default as it may
break debug.