### PR TITLE
Fix recompilation of the CI of meson project.

### DIFF
--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -148,12 +148,6 @@ def make_deps_archive(target=None, name=None, full=False):
         files_to_archive += (HOME / "BUILD_native_static").glob("*/.*_ok")
         files_to_archive += HOME.glob("BUILD_android*/**/.*_ok")
         files_to_archive += SOURCE_DIR.glob("*/.*_ok")
-        files_to_archive += [
-            SOURCE_DIR / "pugixml-{}".format(base_deps_versions["pugixml"])
-        ]
-        files_to_archive += HOME.glob(
-            "BUILD_*/pugixml-{}".format(base_deps_versions["pugixml"])
-        )
         if PLATFORM_TARGET.startswith("armhf"):
             files_to_archive += (SOURCE_DIR / "armhf").glob("*")
         toolchains_subdirs = HOME.glob("BUILD_*/TOOLCHAINS/*/*")

--- a/kiwixbuild/dependencies/kiwix_desktop.py
+++ b/kiwixbuild/dependencies/kiwix_desktop.py
@@ -5,6 +5,7 @@ from .base import (
 
 class KiwixDesktop(Dependency):
     name = "kiwix-desktop"
+    force_build = True
 
     class Source(GitClone):
         git_remote = "https://github.com/kiwix/kiwix-desktop.git"

--- a/kiwixbuild/dependencies/kiwix_lib.py
+++ b/kiwixbuild/dependencies/kiwix_lib.py
@@ -10,6 +10,7 @@ from kiwixbuild._global import option, get_target_step, neutralEnv
 
 class Kiwixlib(Dependency):
     name = "kiwix-lib"
+    force_build = True
 
     class Source(GitClone):
         git_remote = "https://github.com/kiwix/kiwix-lib.git"
@@ -39,6 +40,7 @@ class Kiwixlib(Dependency):
 
 class KiwixlibApp(Dependency):
     name = "kiwix-lib-app"
+    force_build = True
 
     class Source(Kiwixlib.Source):
         name = "kiwix-lib"

--- a/kiwixbuild/dependencies/kiwix_tools.py
+++ b/kiwixbuild/dependencies/kiwix_tools.py
@@ -5,6 +5,7 @@ from .base import (
 
 class KiwixTools(Dependency):
     name = "kiwix-tools"
+    force_build = True
 
     class Source(GitClone):
         git_remote = "https://github.com/kiwix/kiwix-tools.git"

--- a/kiwixbuild/dependencies/libzim.py
+++ b/kiwixbuild/dependencies/libzim.py
@@ -6,6 +6,7 @@ from kiwixbuild._global import option
 
 class Libzim(Dependency):
     name = "libzim"
+    force_build = True
 
     class Source(GitClone):
         git_remote = "https://github.com/openzim/libzim.git"

--- a/kiwixbuild/dependencies/zim_tools.py
+++ b/kiwixbuild/dependencies/zim_tools.py
@@ -5,6 +5,7 @@ from .base import (
 
 class ZimTools(Dependency):
     name = "zim-tools"
+    force_build = True
 
     class Source(GitClone):
         git_remote = "https://github.com/openzim/zim-tools.git"

--- a/kiwixbuild/dependencies/zimwriterfs.py
+++ b/kiwixbuild/dependencies/zimwriterfs.py
@@ -5,6 +5,7 @@ from .base import (
 
 class Zimwriterfs(Dependency):
     name = "zimwriterfs"
+    force_build = True
 
     class Source(GitClone):
         git_remote = "https://github.com/openzim/zimwriterfs.git"

--- a/kiwixbuild/utils.py
+++ b/kiwixbuild/utils.py
@@ -187,8 +187,11 @@ class Context:
         self.log_file = log_file
         self.force_native_build = force_native_build
         self.autoskip_file = None
+        self.no_skip = False
 
     def try_skip(self, path, extra_name=""):
+        if self.no_skip:
+            return
         if extra_name:
             extra_name = "_{}".format(extra_name)
         self.autoskip_file = pj(path, ".{}{}_ok".format(self.command_name, extra_name))

--- a/travis/compile_all.py
+++ b/travis/compile_all.py
@@ -236,10 +236,6 @@ def make_deps_archive(target=None, name=None, full=False):
         files_to_archive += (HOME/"BUILD_native_static").glob('*/.*_ok')
         files_to_archive += HOME.glob('BUILD_android*/**/.*_ok')
         files_to_archive += SOURCE_DIR.glob('*/.*_ok')
-        files_to_archive += [SOURCE_DIR/'pugixml-{}'.format(
-            base_deps_versions['pugixml'])]
-        files_to_archive += HOME.glob('BUILD_*/pugixml-{}'.format(
-            base_deps_versions['pugixml']))
         if PLATFORM.startswith('armhf'):
             files_to_archive += (SOURCE_DIR/'armhf').glob('*')
         toolchains_subdirs = HOME.glob('**/TOOLCHAINS/*/*')


### PR DESCRIPTION
We were assuming that meson project correspond to our projects and so we
were always building them, even if they were already compiled.
(This way, a simple `kiwix-build` is enough to recompile the WIP code of
our project).

However, on the CI, we do not archive the source code/build directory in
the base deps archive. So when we try to compile, the compile step of
meson projects fails because the source are not here.
We have a small workaround for pugixml but as zstd is also meson, it is
time to do something correct.

By default, all projects now try to skip if a build is already present.
Our projects are marked as `force_build` and so, they do not try to skip.