### PR TITLE
Added docopt cpp dependency to zimtools

### DIFF
--- a/kiwixbuild/dependencies/__init__.py
+++ b/kiwixbuild/dependencies/__init__.py
@@ -6,6 +6,7 @@ from . import (
     android_sdk,
     aria2,
     armhf,
+    docoptcpp,
     flatpak,
     gumbo,
     icu4c,

--- a/kiwixbuild/dependencies/all_dependencies.py
+++ b/kiwixbuild/dependencies/all_dependencies.py
@@ -16,5 +16,9 @@ class AllBaseDependencies(Dependency):
             # zimwriterfs
             if platformInfo.build not in ('android', 'win32'):
                 base_deps += ['libmagic', 'gumbo']
+            
+            # zimtools
+            if platformInfo.build not in ('android','iOS'):
+                base_deps += ['docoptcpp']
 
             return base_deps

--- a/kiwixbuild/dependencies/docoptcpp.py
+++ b/kiwixbuild/dependencies/docoptcpp.py
@@ -1,0 +1,20 @@
+from .base import (
+    Dependency,
+    ReleaseDownload,
+    CMakeBuilder)
+
+from kiwixbuild.utils import Remotefile
+
+
+
+class docoptcpp(Dependency):
+    name = 'docoptcpp'
+
+    class Source(ReleaseDownload):
+        archive = Remotefile('v0.6.2.tar.gz',
+                             'c05542245232420d735c7699098b1ea130e3a92bade473b64baf876cdf098a17',
+                             'https://github.com/docopt/docopt.cpp/archive/v0.6.2.tar.gz')
+
+    class Builder(CMakeBuilder):
+        make_install_target = 'install'
+

--- a/kiwixbuild/dependencies/zim_tools.py
+++ b/kiwixbuild/dependencies/zim_tools.py
@@ -12,7 +12,7 @@ class ZimTools(Dependency):
         git_dir = "zim-tools"
 
     class Builder(MesonBuilder):
-        dependencies = ['libzim']
+        dependencies = ['libzim', 'docoptcpp']
 
         @property
         def configure_option(self):

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -42,12 +42,13 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = '66'
+base_deps_meta_version = '67'
 
 base_deps_versions = {
   'zlib' : '1.2.8',
   'lzma' : '5.2.4',
   'zstd' : '1.4.4',
+  'docoptcpp' : '0.6.2',
   'uuid' : '1.43.4',
   'xapian-core' : '1.4.14',
   'mustache' : '4.1',


### PR DESCRIPTION
This PR adds the docopt cpp library to the build environment. It will be needed for zimdump.