### PR TITLE
iOS remove 32bit builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,9 +140,7 @@ jobs:
         target:
           - native_dyn
           - iOS_arm64
-          - iOS_i386
           - iOS_x86_64
-          - iOS_armv7
     runs-on: macos-latest
     env:
       SSH_KEY: /tmp/id_rsa

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,6 @@ jobs:
       os: osx
     - env: PLATFORM="iOS_arm64"
       os: osx
-    - env: PLATFORM="iOS_i386"
-      os: osx
 
 
 

--- a/kiwixbuild/__init__.py
+++ b/kiwixbuild/__init__.py
@@ -57,7 +57,7 @@ def parse_args():
     if not options.android_arch:
         options.android_arch = ['arm', 'arm64', 'x86', 'x86_64']
     if not options.ios_arch:
-        options.ios_arch = ['armv7', 'arm64', 'i386', 'x86_64']
+        options.ios_arch = ['arm64', 'x86_64']
 
     if not options.target_platform:
         if options.target in ('kiwix-lib-app',):

--- a/kiwixbuild/platforms/ios.py
+++ b/kiwixbuild/platforms/ios.py
@@ -78,23 +78,11 @@ class iOSPlatformInfo(PlatformInfo):
     def configure_option(self):
         return '--host={}'.format(self.arch_full)
 
-class iOSArmv7(iOSPlatformInfo):
-    name = 'iOS_armv7'
-    arch = cpu = 'armv7'
-    arch_full =  'armv7-apple-darwin'
-    sdk_name = 'iphoneos'
-
 class iOSArm64(iOSPlatformInfo):
     name = 'iOS_arm64'
     arch = cpu = 'arm64'
     arch_full =  'arm-apple-darwin'
     sdk_name = 'iphoneos'
-
-class iOSi386(iOSPlatformInfo):
-    name = 'iOS_i386'
-    arch = cpu = 'i386'
-    arch_full =  'i386-apple-darwin'
-    sdk_name = 'iphonesimulator'
 
 class iOSx64(iOSPlatformInfo):
     name = 'iOS_x86_64'

--- a/kiwixbuild/platforms/ios.py
+++ b/kiwixbuild/platforms/ios.py
@@ -9,7 +9,7 @@ class iOSPlatformInfo(PlatformInfo):
     build = 'iOS'
     static = True
     compatible_hosts = ['Darwin']
-    min_iphoneos_version = '9.0'
+    min_iphoneos_version = '11.0'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -49,7 +49,7 @@ class iOSPlatformInfo(PlatformInfo):
 
     def get_env(self):
         env = super().get_env()
-        env['MACOSX_DEPLOYMENT_TARGET'] = '10.10'
+        env['MACOSX_DEPLOYMENT_TARGET'] = '10.13'
         return env
 
     def set_comp_flags(self, env):


### PR DESCRIPTION
## Remove 32bit builds for iOS. 

The Kiwix for iOS app no longer supports iOS 10, which means we no longer support 32bit devices. (All devices capable of running iOS 11 are 64 bit). I have actually already shipped two versions of the app with libs build in this branch.

I tried to update CI, but it didn't seem to work... Please help.