### PR TITLE
Release libzim for macOS in the CI

### DIFF
--- a/.github/scripts/build_release_nightly.py
+++ b/.github/scripts/build_release_nightly.py
@@ -13,6 +13,7 @@ from common import (
     create_desktop_image,
     update_flathub_git,
     upload_archive,
+    fix_macos_rpath,
     BASE_DIR,
     TMP_DIR,
     HOME,
@@ -35,7 +36,7 @@ elif PLATFORM_TARGET.startswith("iOS"):
     TARGETS = ("libzim", "kiwix-lib")
 elif PLATFORM_TARGET.startswith("native_"):
     if OS_NAME == "osx":
-        TARGETS = ("libzim", "zimwriterfs", "zim-tools", "kiwix-lib")
+        TARGETS = ("libzim", ) if PLATFORM_TARGET == "native_mixed" else ("libzim", "zimwriterfs", "zim-tools", "kiwix-lib")
     else:
         if DESKTOP:
             TARGETS = ("kiwix-desktop",)
@@ -59,6 +60,8 @@ for target in TARGETS:
     if target == "kiwix-desktop":
         archive = create_desktop_image(make_release=RELEASE)
     else:
+        if PLATFORM_TARGET == "native_mixed" and OS_NAME == "osx":
+            fix_macos_rpath(target)
         archive = make_archive(target, make_release=RELEASE)
     if archive:
         upload_archive(archive, target, make_release=RELEASE)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
       matrix:
         target:
           - native_dyn
+          - native_mixed
           - iOS_arm64
           - iOS_x86_64
     runs-on: macos-latest

--- a/.github/workflows/releaseNigthly.yml
+++ b/.github/workflows/releaseNigthly.yml
@@ -124,6 +124,7 @@ jobs:
       matrix:
         target:
           - native_dyn
+          - native_mixed
     runs-on: macos-latest
     env:
       SSH_KEY: /tmp/id_rsa

--- a/kiwixbuild/platforms/native.py
+++ b/kiwixbuild/platforms/native.py
@@ -21,7 +21,7 @@ class NativeStatic(NativePlatformInfo):
 class NativeMixed(NativePlatformInfo):
     name = 'native_mixed'
     static = False
-    compatible_hosts =  ['fedora', 'debian']
+    compatible_hosts = ['fedora', 'debian', 'Darwin']
 
     def add_targets(self, targetName, targets):
         print(targetName)


### PR DESCRIPTION
Fixes #349 by enabling `native_mixed` for OSX in the CI and release.

- release on macOS is limited to libzim
- libzim shared lib is renamed to strip out the build path
- output release name is customized to produce `-macos-` instead of `-linux`

- For this to produce a macOS release, we have to change libzim version to `0` ; included it here but that may not be wanted (66eb4fa)