### PR TITLE
Force compilation of docoptcpp

### DIFF
--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -42,7 +42,7 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = '67'
+base_deps_meta_version = '68'
 
 base_deps_versions = {
   'zlib' : '1.2.8',


### PR DESCRIPTION
Docopt commit id was updated and therefore we need to force a new build in order to get the latest change (docoptcpp.pc) into the deps2 archive (needed by zim-tools)