### PR TITLE
Fix macos brew install packages.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,9 +126,8 @@ jobs:
       with:
         python-version: '3.6'
     - name: Install packages
-      uses: mstksg/get-package@v1
-      with:
-        brew: pkg-config ninja
+      run:
+        brew install pkg-config ninja
     - name: Install python modules
       run: |
         pip3 install meson==0.52.1 pytest requests distro


### PR DESCRIPTION
Directly use brew instead of `get-package` action.
`get-package` seems to be broken with some invalid git command.