### PR TITLE
Trigger docker publish on release

### DIFF
--- a/.github/scripts/build_release_nightly.py
+++ b/.github/scripts/build_release_nightly.py
@@ -14,6 +14,7 @@ from common import (
     update_flathub_git,
     upload_archive,
     fix_macos_rpath,
+    trigger_docker_publish,
     BASE_DIR,
     TMP_DIR,
     HOME,
@@ -75,6 +76,8 @@ for target in TARGETS:
         archive = make_archive(target, make_release=RELEASE)
     if archive:
         upload_archive(archive, target, make_release=RELEASE)
+        if RELEASE and target in ("zim-tools", "kiwix-tools"):
+            trigger_docker_publish(target)
 
 # We have few more things to do for release:
 if RELEASE:

--- a/.github/workflows/releaseNigthly.yml
+++ b/.github/workflows/releaseNigthly.yml
@@ -113,6 +113,7 @@ jobs:
         PLATFORM_TARGET: ${{matrix.target}}
         BINTRAY_USER: kiwix
         BINTRAY_PASS: ${{secrets.bintray_pass}}
+        GITHUB_PAT: ${{secrets.GHCR_TOKEN}}
     - name: Upload failure logs
       if: failure()
       run: $HOME/kiwix-build/.github/scripts/upload_failure_logs.sh


### PR DESCRIPTION
This triggers a `workflow_dispatch` event on the `docker.yml` workflow or the matching
repository for both `zim-tools` and `kiwix-tools` targets that supports it.

@mgautierfr this uses requests as requests is already used in upload_bintray and thus installed in the images used. I had a version using only urllib if you'd prefer.

Also, this is based on the filtering that is already done in the matrix and earlier in the script so it's just triggered after the upload of the binaries but that may not be obvious.

Finally, this just prints on error ; should we raise/fail? How critical is this given it can be triggered manually…