### PR TITLE
Use brew ls --version

### DIFF
--- a/kiwixbuild/builder.py
+++ b/kiwixbuild/builder.py
@@ -161,7 +161,7 @@ class Builder:
             package_checker = 'LANG=C dpkg -s {} 2>&1 | grep Status | grep "ok installed" 1>/dev/null 2>&1'
         elif distname == 'Darwin':
             package_installer = 'brew install {}'
-            package_checker = 'brew list -1 | grep -q {}'
+            package_checker = 'brew ls --version {} > /dev/null'
 
         packages_to_install = []
         for package in packages_to_have:


### PR DESCRIPTION
Home brew recently deprecated `brew list`, resulting in errors when determining if automake etc. exists:

```
(venv) chrisli@Chriss-Mac-Pro kiwix-build % kiwix-build --target-platform iOS_multi kiwix-lib
[INSTALL PACKAGES]
Error: Calling `brew list` to only list formulae is disabled! Use `brew list --formula` instead.
 - autoconf : NEEDED
Error: Calling `brew list` to only list formulae is disabled! Use `brew list --formula` instead.
 - automake : NEEDED
Error: Calling `brew list` to only list formulae is disabled! Use `brew list --formula` instead.
 - libtool : NEEDED
Error: Calling `brew list` to only list formulae is disabled! Use `brew list --formula` instead.
 - cmake : NEEDED
```

In this PR, I am updating the subprocess call used to determine if a certain brew formula is installed to `brew ls --version`