### PR TITLE
Notarizing libzim release for macOS

### DIFF
--- a/.github/scripts/build_release_nightly.py
+++ b/.github/scripts/build_release_nightly.py
@@ -21,6 +21,7 @@ from common import (
     OS_NAME,
     PLATFORM_TARGET,
     DESKTOP,
+    notarize_macos_build,
 )
 
 from upload_to_bintray import upload_from_json
@@ -73,6 +74,7 @@ for target in TARGETS:
     else:
         if PLATFORM_TARGET == "native_mixed" and OS_NAME == "osx":
             fix_macos_rpath(target)
+            notarize_macos_build(target)
         archive = make_archive(target, make_release=RELEASE)
     if archive:
         upload_archive(archive, target, make_release=RELEASE)

--- a/.github/workflows/releaseNigthly.yml
+++ b/.github/workflows/releaseNigthly.yml
@@ -132,6 +132,10 @@ jobs:
     env:
       SSH_KEY: /tmp/id_rsa
       OS_NAME: osx
+      CERTIFICATE: /tmp/wmch-devid.p12
+      SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+      ALTOOL_USERNAME: ${{ secrets.APPLE_SIGNING_ALTOOL_USERNAME }}
+      ASC_PROVIDER: ${{ secrets.APPLE_SIGNING_TEAM }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
@@ -151,6 +155,19 @@ jobs:
       run: |
         echo "${{secrets.ssh_key}}" > $SSH_KEY
         chmod 600 $SSH_KEY
+    - name: install Apple certificate
+      shell: bash
+      run: |
+        echo "${{ secrets.APPLE_SIGNING_CERTIFICATE }}" | base64 --decode -o $CERTIFICATE
+        security create-keychain -p mysecretpassword build.keychain
+        security default-keychain -s build.keychain
+        security unlock-keychain -p mysecretpassword build.keychain
+        security import $CERTIFICATE -k build.keychain -P "${{ secrets.APPLE_SIGNING_P12_PASSWORD }}" -A
+        rm $CERTIFICATE
+        "security set-key-partition-list -S apple-tool:,apple: -s -k mysecretpassword build.keychain"
+        security find-identity -v
+        sntp -sS time.apple.com
+        xcrun altool --store-password-in-keychain-item "ALTOOL_PASSWORD" -u "$ALTOOL_USERNAME" -p "${{ secrets.APPLE_SIGNING_ALTOOL_PASSWORD }}"
     - name: Ensure base deps
       shell: bash
       run: |


### PR DESCRIPTION
This adds the notarization (see #469) of the libzim binary for macOS during the build.
It it not dependent on RELEASE so it benefits all builds.

It basically does two things:
- sign the build with our Developer ID certificate from Apple.
- Request notarization from Apple for the binary.
At the moment, it concerns only libzim. Might expand that to libkiwix and the zim/kiwix tools
once we start releasing those.

Github Actions prepare the certificate and environment, and signing+request is done in `notarize_macos_build()` (common.py)

It required the following new secrets:

| secret | value |
|---|---|
| `APPLE_SIGNING_CERTIFICATE` | base64 of the P12 certificate |
| `APPLE_SIGNING_P12_PASSWORD` | password for the P12 certificate (we chose that when exporting to P12. Apple doesnt provide P12) |
| `APPLE_SIGNING_IDENTITY`| Common name of our certificate. Not a private info but seems better suited there than in the CI |
| `APPLE_SIGNING_TEAM`| Apple Developer Team ID (mentionned in the signing identity) |
| `APPLE_SIGNING_ALTOOL_PASSWORD`| app-specific password created to request notarization |
| `APPLE_SIGNING_ALTOOL_USERNAME`| username associated with the app-specific password. Must be an Apple ID with perms on the Certificate. Currently mine. |