### PR TITLE
time update requires sudo

### DIFF
--- a/.github/workflows/releaseNigthly.yml
+++ b/.github/workflows/releaseNigthly.yml
@@ -166,7 +166,7 @@ jobs:
         rm $CERTIFICATE
         security set-key-partition-list -S "apple-tool:,apple:" -s -k mysecretpassword build.keychain
         security find-identity -v
-        sntp -sS time.apple.com
+        sudo sntp -sS time.apple.com
         xcrun altool --store-password-in-keychain-item "ALTOOL_PASSWORD" -u "$ALTOOL_USERNAME" -p "${{ secrets.APPLE_SIGNING_ALTOOL_PASSWORD }}"
     - name: Ensure base deps
       shell: bash


### PR DESCRIPTION
We update the time when installing the certificate because there's a timestamp comparison during signing and that prevents signing failures due to clock drifting in the containers.

Updating time using ntp does requires sudo though.