### PR TITLE
allow more time for ntp server to respond

### DIFF
--- a/.github/workflows/releaseNigthly.yml
+++ b/.github/workflows/releaseNigthly.yml
@@ -166,7 +166,7 @@ jobs:
         rm $CERTIFICATE
         security set-key-partition-list -S "apple-tool:,apple:" -s -k mysecretpassword build.keychain
         security find-identity -v
-        sudo sntp -sS time.apple.com
+        sudo sntp -sS time.apple.com -t 60
         xcrun altool --store-password-in-keychain-item "ALTOOL_PASSWORD" -u "$ALTOOL_USERNAME" -p "${{ secrets.APPLE_SIGNING_ALTOOL_PASSWORD }}"
     - name: Ensure base deps
       shell: bash


### PR DESCRIPTION
This is not strictly required but sometimes the time server doesn't respond within the default timeout (5s), making the whole build fail.
This just sets a 60s timeout instead so a slow-response request would still succeed and the build will proceed.