### PR TITLE
Change time server in workflow

### DIFF
--- a/.github/workflows/releaseNigthly.yml
+++ b/.github/workflows/releaseNigthly.yml
@@ -166,7 +166,7 @@ jobs:
         rm $CERTIFICATE
         security set-key-partition-list -S "apple-tool:,apple:" -s -k mysecretpassword build.keychain
         security find-identity -v
-        sudo sntp -sS time.apple.com -t 60
+        sudo sntp -sS -t 60 time4.google.com || true
         xcrun altool --store-password-in-keychain-item "ALTOOL_PASSWORD" -u "$ALTOOL_USERNAME" -p "${{ secrets.APPLE_SIGNING_ALTOOL_PASSWORD }}"
     - name: Ensure base deps
       shell: bash


### PR DESCRIPTION
For the past week, the Release&Nightly workflow failed on macOS native_mixed
(but not on native_dyn) when calling ntp to sync clock before signing.
Calling time.apple.com resulted in a DNS error, leading to an error in ntp call

Why this fails on native_mixed is unknown. Maybe because it's being called twice
from the same (I guess) host in a short interleave?

This attempts to fix this by:
- using google's time server instead of Apple's
- correctly setting the timeout param before the server name (although not relevant
for this dns-based error)
- Ignore failures to sync time. We're doing it to minimize chances of unsynched clocks
to fail the signature but this is not absolutely required all the time.