### PR TITLE
Language data is packaged into ICU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
         python-version: '3.6'
     - name: Install packages
       run:
-        brew install pkg-config ninja
+        brew install pkg-config ninja automake autoconf
     - name: Install python modules
       run: |
         pip3 install meson==0.52.1 pytest requests distro

--- a/.github/workflows/releaseNigthly.yml
+++ b/.github/workflows/releaseNigthly.yml
@@ -145,7 +145,7 @@ jobs:
         python-version: '3.6'
     - name: Install packages
       run:
-        brew install pkg-config ninja
+        brew install pkg-config ninja automake autoconf
     - name: Install python modules
       run: |
         pip3 install meson==0.52.1 pytest requests distro

--- a/kiwixbuild/patches/icu4c_custom_data.patch
+++ b/kiwixbuild/patches/icu4c_custom_data.patch
@@ -34,13 +34,12 @@ diff -ur icu4c/source/data/Makefile.in icu4c.patched/source/data/Makefile.in
  ## RES files
 --include $(LOCSRCDIR)/resfiles.mk
 --include $(CURRSRCDIR)/resfiles.mk
---include $(LANGSRCDIR)/resfiles.mk
++#-include $(LOCSRCDIR)/resfiles.mk
++#-include $(CURRSRCDIR)/resfiles.mk
+ -include $(LANGSRCDIR)/resfiles.mk
 --include $(REGIONSRCDIR)/resfiles.mk
 --include $(ZONESRCDIR)/resfiles.mk
 --include $(UNITSRCDIR)/resfiles.mk
-+#-include $(LOCSRCDIR)/resfiles.mk
-+#-include $(CURRSRCDIR)/resfiles.mk
-+#-include $(LANGSRCDIR)/resfiles.mk
 +#-include $(REGIONSRCDIR)/resfiles.mk
 +#-include $(ZONESRCDIR)/resfiles.mk
 +#-include $(UNITSRCDIR)/resfiles.mk

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -39,7 +39,7 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = '73'
+base_deps_meta_version = '74'
 
 base_deps_versions = {
   'zlib' : '1.2.8',


### PR DESCRIPTION
With language data not put into the ICU package, `icu::Locale::getDisplayLanguage()` doesn't work correctly. This is required by kiwix/libkiwix#553 (see https://github.com/kiwix/libkiwix/pull/553/commits/0198cdafaeddc6fe12a9875f4525effb998f4671).