### PR TITLE
[WINDOWS][CI] Be explicit about the algorithm used by signtools.

### DIFF
--- a/appveyor/package_kiwix-desktop.sh
+++ b/appveyor/package_kiwix-desktop.sh
@@ -27,7 +27,7 @@ then
   cp $MINGW64_EXTRA_DIR/aria2c.exe $KIWIX_DIR
   cp $MINGW64_EXTRA_DIR/bin/*.dll $KIWIX_DIR
 
-  signtool.exe sign -f appveyor/kiwix.pfx -p $win_certificate_password -t http://timestamp.digicert.com -d "Kiwix-desktop application" $KIWIX_DIR/kiwix-desktop.exe
+  signtool.exe sign -f appveyor/kiwix.pfx -p $win_certificate_password -t http://timestamp.digicert.com -d "Kiwix-desktop application" -fd SHA256 $KIWIX_DIR/kiwix-desktop.exe
 
   7z a -tzip $KIWIX_ARCHIVES_DIR/$KIWIX_ARCH_NAME $KIWIX_DIR
 fi


### PR DESCRIPTION
Recent version of signtools need us to be explicit about the used
algorithm.
This is recommended to use the SHA256 algorithm even if the default
(previous) one was SHA1.