### PR TITLE
macOS Builds (arm64 + x86)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,8 @@ jobs:
           - iOS_arm64
           - iOS_x86_64
           - iOS_Mac_ABI
+          - macOS_arm64
+          - macOS_x86_64
     runs-on: macos-latest
     env:
       SSH_KEY: /tmp/id_rsa


### PR DESCRIPTION
## Rationale

Adding macOS platforms -- Intel(x86) & Apple Silicon(arm64), along with a couple of other things:

- rename the base class to `ApplePlatformInfo` since it is not just about iOS anymore
- update CI to build with the newly created macOS subclasses, removing targets that I don't use (e.g.`native_dyn`)