### PR TITLE
Force version of python's module on xenial.

### DIFF
--- a/.github/ci_images/xenial_builder.dockerfile
+++ b/.github/ci_images/xenial_builder.dockerfile
@@ -21,7 +21,7 @@ RUN apt update -q \
 #    vim less grep \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* /usr/share/doc/* /var/cache/debconf/* \
-  && pip3 install meson==0.52.1 pytest gcovr requests distro
+  && pip3 install meson==0.52.1 pytest 'markupsafe<2.0.0' 'jinja2<3.0.0' 'gcovr<5.0' requests distro
 
 # Create user
 RUN useradd --create-home runner


### PR DESCRIPTION
Xenial's python is 3.5 and recent versions of used python modules are
not supporting python 3.5 anymore.
We have to force specific versions for gcovr and its dependencies.