### PR TITLE
Disable extra libcurl dependencies

### DIFF
--- a/kiwixbuild/dependencies/libcurl.py
+++ b/kiwixbuild/dependencies/libcurl.py
@@ -22,7 +22,8 @@ class LibCurl(Dependency):
         dependencies = ['zlib']
         configure_option = " ".join(
             ["--without-{}".format(p)
-                for p in ('libssh2', 'ssl', 'libmetalink', 'librtmp')] +
+                for p in ('libssh2', 'ssl', 'libmetalink', 'librtmp',
+                          'nghttp2', 'libidn2', 'brotli')] +
             ["--disable-{}".format(p)
                 for p in ('ftp', 'file', 'ldap', 'ldaps', 'rtsp', 'dict',
                           'telnet', 'tftp', 'pop3', 'imap', 'smb', 'smtp',


### PR DESCRIPTION
#501: when compiling libcurl, disable a few not-used dependencies for which we don't have symbols on some platform.

FYI, libcurl is used solely to talk with aria2 interface.