### PR TITLE
Fix setting of `SYSTEMLIBDIR` in the appimage creation script.

### DIFF
--- a/scripts/create_kiwix-desktop_appImage.sh
+++ b/scripts/create_kiwix-desktop_appImage.sh
@@ -7,7 +7,7 @@ SOURCEDIR=${2:-$PWD/SOURCE/kiwix-desktop}
 APPDIR=${3:-$PWD/AppDir}
 
 SYSTEMLIBDIR=lib/x86_64-linux-gnu
-if [ ! -e "$APPDIR/lib" ] ; then
+if [ ! -e "$INSTALLDIR/lib" ] ; then
   SYSTEMLIBDIR=lib64
 fi
 


### PR DESCRIPTION
If it is the first time the script is run, $APPDIR doesn't exist, so,
by definition, `$APPDIR/lib` doesn't exists neither.

We must check the library dir in `$INSTALLDIR` which is the "source"
directory for script.