### PR TITLE
Do not compile libkiwix on android with werror

### DIFF
--- a/kiwixbuild/dependencies/libkiwix.py
+++ b/kiwixbuild/dependencies/libkiwix.py
@@ -24,7 +24,7 @@ class Libkiwix(Dependency):
         def configure_option(self):
             platformInfo = self.buildEnv.platformInfo
             if platformInfo.build == 'android':
-                return '-Dwrapper=android'
+                return '-Dwrapper=android -Dwerror=false'
             if platformInfo.build == 'iOS':
                 return '-Db_bitcode=true'
             if platformInfo.name == 'flatpak':


### PR DESCRIPTION
The java wrapper is using deprecated methods, so we cannot compile with `werror`.