### PR TITLE
Do not include low level std lib in appimage package

### DIFF
--- a/scripts/create_kiwix-desktop_appImage.sh
+++ b/scripts/create_kiwix-desktop_appImage.sh
@@ -23,9 +23,6 @@ cp $INSTALLDIR/$SYSTEMLIBDIR/*.so* $APPDIR/usr/lib
 rm -f $APPDIR/usr/lib/libmagic.so*
 # Copy nss lib (to not conflict with host's ones)
 cp -a /usr/$SYSTEMLIBDIR/nss $APPDIR/usr/lib
-cp -a /usr/$SYSTEMLIBDIR/libstdc++.so* $APPDIR/usr/lib
-cp -a /usr/$SYSTEMLIBDIR/libc.so* $APPDIR/usr/lib
-cp -a /usr/$SYSTEMLIBDIR/libz.so* $APPDIR/usr/lib
 cp $ICONFILE $APPDIR/usr/share/icons/hicolor/48x48/apps/kiwix-desktop.svg
 mkdir -p $APPDIR/usr/share/applications
 cp $DESKTOPFILE $APPDIR/usr/share/applications/kiwix-desktop.desktop


### PR DESCRIPTION
We have added those libraries to fix kiwix/kiwix-destop#14,
ie allow appimage build on recent system to run on older ones by packaging
the libc and libstdc++ library in the appimage.

But by packaging libstdc++, we force kiwix-desktop to use the packaged one.
On some recent system, the mesa drivers need a recent version of libstdc++ and,
as we are force to use the packaged one, we may use a "old" one.

The workaround forcing a driver was bypassing the problem by forcing a driver
not using a recent libstdc++. But with time, it is more and more difficult
to find one.

This commit means that new appimage generated will works only on equal or
more recent system that the one on which it has been generated.
For now we generate the appimage on Ubuntu bionic (18.04 LTS).

This reverts commit 05c0a691ec407a6ae53d9b8f405bce90e119ae3e.

Fix kiwix/kiwix-desktop#745 and kiwix/kiwix-desktop#393