### PR TITLE
Fix workflow triggering in releaseNigthly workflow.

### DIFF
--- a/.github/workflows/releaseNigthly.yml
+++ b/.github/workflows/releaseNigthly.yml
@@ -109,6 +109,7 @@ jobs:
         PLATFORM_TARGET: ${{matrix.target}}
         BINTRAY_USER: kiwix
         BINTRAY_PASS: ${{secrets.bintray_pass}}
+        GITHUB_PAT: ${{secrets.GHCR_TOKEN}}
     - name: Upload failure logs
       if: failure()
       run: $HOME/kiwix-build/.github/scripts/upload_failure_logs.sh
@@ -154,8 +155,6 @@ jobs:
       run: |
         cd $HOME
         kiwix-build/.github/scripts/build_release_nightly.py
-      env:
-        GITHUB_PAT: ${{secrets.GHCR_TOKEN}}
     - name: Upload failure logs
       if: failure()
       run: $HOME/kiwix-build/.github/scripts/upload_failure_logs.sh


### PR DESCRIPTION
GITHUB_PAT is needed (and not needed for flatpak)