### PR TITLE
Trust codesign using the certificate

### DIFF
--- a/.github/scripts/build_projects.py
+++ b/.github/scripts/build_projects.py
@@ -9,7 +9,6 @@ from common import (
     OS_NAME,
     PLATFORM_TARGET,
     DESKTOP,
-    notarize_macos_build,
 )
 
 if PLATFORM_TARGET.startswith("android_"):
@@ -43,5 +42,4 @@ for target in TARGETS:
     else:
         if PLATFORM_TARGET == "native_mixed" and OS_NAME == "osx":
             fix_macos_rpath(target)
-            notarize_macos_build(target)
         make_archive(target, make_release=False)

--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -483,6 +483,8 @@ def notarize_macos_build(project):
     for filepath in filepaths:
         subprocess.check_call(["/usr/bin/codesign", "--force", "--sign",
                                os.getenv("SIGNING_IDENTITY", "no-signing-ident"),
+                               "--keychain",
+                               os.getenv("KEYCHAIN", "no-keychain-path"),
                                str(filepath), "--deep", "--timestamp"], env=os.environ)
 
     # create a zip of the dylibs and upload for notarization

--- a/.github/workflows/releaseNigthly.yml
+++ b/.github/workflows/releaseNigthly.yml
@@ -174,6 +174,7 @@ jobs:
       SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
       ALTOOL_USERNAME: ${{ secrets.APPLE_SIGNING_ALTOOL_USERNAME }}
       ASC_PROVIDER: ${{ secrets.APPLE_SIGNING_TEAM }}
+      KEYCHAIN: /Users/runner/build.keychain-db
     steps:
     - name: Checkout code
       uses: actions/checkout@v1
@@ -197,15 +198,16 @@ jobs:
       shell: bash
       run: |
         echo "${{ secrets.APPLE_SIGNING_CERTIFICATE }}" | base64 --decode -o $CERTIFICATE
-        security create-keychain -p mysecretpassword build.keychain
-        security default-keychain -s build.keychain
-        security unlock-keychain -p mysecretpassword build.keychain
-        security import $CERTIFICATE -k build.keychain -P "${{ secrets.APPLE_SIGNING_P12_PASSWORD }}" -A
+        security create-keychain -p mysecretpassword $KEYCHAIN
+        security default-keychain -s $KEYCHAIN
+        security set-keychain-settings $KEYCHAIN
+        security unlock-keychain -p mysecretpassword $KEYCHAIN
+        security import $CERTIFICATE -k $KEYCHAIN -P "${{ secrets.APPLE_SIGNING_P12_PASSWORD }}" -A -T "/usr/bin/codesign"
         rm $CERTIFICATE
-        security set-key-partition-list -S "apple-tool:,apple:" -s -k mysecretpassword build.keychain
-        security find-identity -v
+        security set-key-partition-list -S apple-tool:,apple: -s -k mysecretpassword $KEYCHAIN
+        security find-identity -v $KEYCHAIN
         sudo sntp -sS -t 60 time4.google.com || true
-        xcrun altool --store-password-in-keychain-item "ALTOOL_PASSWORD" -u "$ALTOOL_USERNAME" -p "${{ secrets.APPLE_SIGNING_ALTOOL_PASSWORD }}"
+        xcrun altool --keychain $KEYCHAIN --store-password-in-keychain-item "ALTOOL_PASSWORD" -u "$ALTOOL_USERNAME" -p "${{ secrets.APPLE_SIGNING_ALTOOL_PASSWORD }}"
     - name: Ensure base deps
       shell: bash
       run: |


### PR DESCRIPTION
When build_release_nightly calls codesign to sign libzim.7.dylib, it appears to be hanging forever.
What's most likely happening is that Keychain Access is prompting a password request without any possibility to answer, given this is running on the CI.

It's unclear whether Keychain Access wants to confirm codesign can access the certificate or if it is trying to unlock another (System) keychain to find the certificate or key.

This addresses the former.

Fixes #519, tested in [this run](https://github.com/kiwix/kiwix-build/runs/6407707440?check_suite_focus=true)