### PR TITLE
Added CI image for Alpine

### DIFF
--- a/.github/ci_images/alpine_builder.dockerfile
+++ b/.github/ci_images/alpine_builder.dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:3.16
+
+ENV LANG C.UTF-8
+ENV OS_NAME alpine
+
+RUN apk update -q \
+  && apk add -q --no-cache \
+# Base build tools
+        bash build-base git py3-pip \
+# Packaged dependencies
+        xz-dev \
+        zstd-dev \
+        xapian-core-dev \
+        icu-dev icu-data-full \
+        gtest-dev
+
+# Create user
+RUN adduser -h /home/runner -D runner
+USER runner
+WORKDIR /home/runner
+ENV PATH /home/runner/.local/bin:$PATH
+RUN pip3 install meson ninja ; \
+    ln -s /usr/bin/python3 .local/bin/python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: [bionic, f35, focal]
+        variant: [bionic, f35, focal, alpine]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/releaseNigthly.yml
+++ b/.github/workflows/releaseNigthly.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        variant: [bionic, f35, focal]
+        variant: [bionic, f35, focal, alpine]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Related to openzim/libzim#709

The PR only enhances the Docker job so that it creates Alpine images that can be used in the openzim/libzim CI. Alpine is not added to the list of configurations used in the kiwix-build CI workflows.