### PR TITLE
Publish the CI only if we are on a dev branch.

### DIFF
--- a/.github/scripts/build_projects.py
+++ b/.github/scripts/build_projects.py
@@ -47,5 +47,5 @@ for target in TARGETS:
         if PLATFORM_TARGET == "native_mixed" and OS_NAME == "osx":
             fix_macos_rpath(target)
         archive = make_archive(target, make_release=False)
-    if archive:
+    if archive and DEV_BRANCH:
         upload_archive(archive, target, make_release=False, dev_branch=DEV_BRANCH)


### PR DESCRIPTION
If we try to publish all the time, we will conflict with `Release&Nigthly` workflow as we would pulbish in nigthly directory.

Fix #550