### PR TITLE
Install wasm libraries in `INSTALL/lib` directory.

### DIFF
--- a/kiwixbuild/platforms/wasm.py
+++ b/kiwixbuild/platforms/wasm.py
@@ -9,6 +9,7 @@ class WasmPlatformInfo(PlatformInfo):
     static = True
     build = 'wasm'
     arch_full = 'wasm64-emscripten'
+    libdir = "lib"
     #arch_full = 'wasm64-linux'
     toolchain_names = ['emsdk']
     compatible_hosts = ['fedora', 'debian']

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -39,7 +39,7 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = '80'
+base_deps_meta_version = '81'
 
 base_deps_versions = {
   'zlib' : '1.2.12',


### PR DESCRIPTION
The default detected libdir is based on the build architecture. On ubuntu, it is `lib/x86_64-linux-gnu` which is obviously not the right directory.

Let's simply use `lib`.

Fix #556