### PR TITLE
Correctly package wasm archives.

### DIFF
--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -94,7 +94,7 @@ EXPORT_FILES = {
         INSTALL_DIR,
         (
             # We need to package all dependencies (`*.a`) on wasm
-            "lib/*/libzim.a" if PLATFORM_TARGET != "wasm" else "lib/*/*.a",
+            "lib/*/libzim.a" if PLATFORM_TARGET != "wasm" else "lib/*.a",
             "lib/*/libzim.so",
             "lib/*/libzim.so.{version}".format(
                 version=main_project_versions["libzim"]


### PR DESCRIPTION
With commit 6181d7bb, we have changed where archives are written. We must addapt our packaging script.

Fix #556