### PR TITLE
Set back the version of libzim to 8.1.0

### DIFF
--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -1,7 +1,7 @@
 # This file reference all the versions of the depedencies we use in kiwix-build.
 
 main_project_versions = {
-    'libzim': '8.1.1',
+    'libzim': '8.1.0',
     'libkiwix': '12.0.0',
     'kiwix-tools': '3.4.0',
     'zim-tools': '3.1.3',
@@ -29,7 +29,7 @@ main_project_versions = {
 # - set KIWIX_DESKTOP_RELEASE to 0
 
 release_versions = {
-    'libzim': 0, # Depends of base deps (was 1)
+    'libzim': None, # Depends of base deps (was 0)
     'libkiwix': None, # Depends of libzim (was 1)
     'kiwix-tools': None, # Depends of libkiwix and libzim (was 1)
     'zim-tools': None, # Depends of libzim (was 2)


### PR DESCRIPTION
The version of libzim (and other project too) is used to know what we need to package in the published archive (nightly and releasee).

So the version must correspond to what is build.
For nightlies, we build the `main` branch and the main branch of libzim is still on 8.1.0 so we must have the same version.

Fix openzim/libzim#772