### PR TITLE
Fix cross-compilation to raspberry-pi.

### DIFF
--- a/kiwixbuild/dependencies/armhf.py
+++ b/kiwixbuild/dependencies/armhf.py
@@ -4,8 +4,8 @@ from kiwixbuild.utils import Remotefile
 
 base_url = 'https://master.dl.sourceforge.net/project/raspberry-pi-cross-compilers/'
 
-# This is Gcc 10.3.0 and Raspberry Pi 2 and 3 only !
-armhf_base_url = base_url + 'Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Stretch/GCC%2010.3.0/Raspberry%20Pi%202%2C%203/'
+# This is Gcc 10.3.0 and Raspberry Pi 2 and 3 !
+armhf_base_url = base_url + 'Raspberry%20Pi%20GCC%20Cross-Compiler%20Toolchains/Bullseye/GCC%2010.3.0/Raspberry%20Pi%202%2C%203/'
 
 # This is Gcc 10.3.0 and ALL rapsberry Pi arch64
 aarch_base_url = base_url + 'Bonus%20Raspberry%20Pi%20GCC%2064-Bit%20Toolchains/Raspberry%20Pi%20GCC%2064-Bit%20Cross-Compiler%20Toolchains/Stretch/GCC%206.3.0/'
@@ -16,8 +16,8 @@ class armhf_toolchain(Dependency):
     name = 'armhf'
 
     class Source(ReleaseDownload):
-        archive = Remotefile('cross-gcc-10.3.0-pi_2-3.tar.gz',
-                             '6aef31703fb7bfd63065dda7fb525f1f86a0509c4358c57631a51025805278b3',
+        archive = Remotefile('bullseyes-cross-gcc-10.3.0-pi_2-3.tar.gz',
+                             'c38f7e5c0126312a6b7fd863cd479e0c54844c63640b7b351d3f41a291a0c78e',
                              armhf_base_url + 'cross-gcc-10.3.0-pi_2-3.tar.gz')
 
     Builder = NoopBuilder

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -39,7 +39,7 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = '86'
+base_deps_meta_version = '87'
 
 base_deps_versions = {
   'zlib' : '1.2.12',


### PR DESCRIPTION
Use a toolschain made for debian Bullseye (or equivalent). Using the Stretch toolschain, kiwix-serve launch but crash with a SIGSEGV at first request.
(I suspect a "conflict" between thread and exception handling as a test program with exception only works).

Moving the a toolschain targeting Bullseye fixes the issues (both on qemu and real raspberry-pi v3 B).

Note that the toolschain is given to compile for Pi 2 and 3 only. I've also tested with toolschain for Pi 3A+, 3B+, 4 and generated binary also works.
Not tested of Pi Zero.


Fix #613