### PR TITLE
Add missing env variable.

### DIFF
--- a/.github/workflows/releaseNigthly.yml
+++ b/.github/workflows/releaseNigthly.yml
@@ -240,6 +240,9 @@ jobs:
   Trigger_Docker:
     needs: [Linux]
     runs-on: ubuntu-22.04
+    env:
+      PLATFORM_TARGET: LINUX_DOCKER_TRIGGER
+      OS_NAME: LINUX_DOCKER_TRIGGER
     steps:
     - name: Checkout code
       uses: actions/checkout@v3


### PR DESCRIPTION
The variables are not used in the context of docker triggering.

I prefer set dummy variables instead of use a default value in the code to be sure that the variable are defined when needed.