### PR TITLE
Update Apple Platforms

### DIFF
--- a/.github/scripts/build_definition.py
+++ b/.github/scripts/build_definition.py
@@ -15,49 +15,48 @@ import csv, io, re
 # 'D' letter means we trigger the docker forkflow to build the docker image.
 # If a cell contains several letters, all are done.
 BUILD_DEF = """
-    | OS_NAME | PLATFORM_TARGET    | libzim | libkiwix | zim-tools | kiwix-tools | kiwix-desktop | platform_name        |
-    =====================================================================================================================
+    | OS_NAME | PLATFORM_TARGET     | libzim | libkiwix | zim-tools | kiwix-tools | kiwix-desktop | platform_name        |
+    ======================================================================================================================
 # Bionic is a special case as we need to compile libzim on old arch for python
-    | bionic  | native_mixed       | BP     |          |           |             |               | linux-x86_64-bionic  |
-    | bionic  | aarch64_mixed      | BP     |          |           |             |               | linux-aarch64-bionic |
-    --------------------------------------------------------------------------------------------------------------------
-# Osx builds, build binaries on native_dyn and native_static. On anyother things, build only the libraries
-    | macos   | native_dyn         | d      | d        | dB        | B           |               |                      |
-    | macos   | native_static      |        |          | BP        | BP          |               | macos-x86_64         |
-    | macos   | native_mixed       | BP     | BP       |           |             |               | macos-x86_64         |
-    | macos   | iOS_arm64          | dB     | B        |           |             |               |                      |
-    | macos   | iOS_x86_64         | dB     | B        |           |             |               |                      |
-    | macos   | iOS_Mac_ABI        | B      | B        |           |             |               |                      |
-    | macos   | macOS_arm64_static |        |          |           |             |               |                      |
-    | macos   | macOS_arm64_mixed  | BP     | BP       |           |             |               | macos-arm64          |
-    | macos   | macOS_x86_64       | B      | B        |           |             |               |                      |
-    ----------------------------------------------------------------------------------------------
-    |         | flatpak            |        |          |           |             | BP            |                      |
-    |         | native_static      | d      | d        | dBPSD     | dBPSD       |               | linux-x86_64         |
-    |         | native_mixed       | BPS    | BPS      |           |             |               | linux-x86_64         |
-    |         | native_dyn         | d      | d        | dB        | dB          | dBPS          |                      |
+    | bionic  | native_mixed        | BP     |          |           |             |               | linux-x86_64-bionic  |
+    | bionic  | aarch64_mixed       | BP     |          |           |             |               | linux-aarch64-bionic |
+    ----------------------------------------------------------------------------------------------------------------------
+# macOS builds, build binaries on native_dyn and native_static. On another things, build only the libraries
+    | macos   | native_dyn          | d      | d        | dB        | B           |               |                      |
+    | macos   | native_static       |        |          | BP        | BP          |               | macos-x86_64         |
+    | macos   | native_mixed        | BP     | BP       |           |             |               | macos-x86_64         |
+    | macos   | iOS_arm64           | B      | B        |           |             |               |                      |
+    | macos   | iOS_simulator_x86   | B      | B        |           |             |               |                      |
+    | macos   | iOS_simulator_arm64 | B      | B        |           |             |               |                      |
+    | macos   | macOS_arm64         | B      | B        |           |             |               | macos-arm64          |
+    | macos   | macOS_x86           | B      | B        |           |             |               |                      |
+    ----------------------------------------------------------------------------------------------------------------------
+    |         | flatpak             |        |          |           |             | BP            |                      |
+    |         | native_static       | d      | d        | dBPSD     | dBPSD       |               | linux-x86_64         |
+    |         | native_mixed        | BPS    | BPS      |           |             |               | linux-x86_64         |
+    |         | native_dyn          | d      | d        | dB        | dB          | dBPS          |                      |
     # libzim CI is building alpine_dyn but not us
-    |         | android_arm        | dBP    | dBP      |           |             |               | android-arm          |
-    |         | android_arm64      | dBP    | dBP      |           |             |               | android-arm64        |
-    |         | android_x86        | BP     | BP       |           |             |               | android-x86          |
-    |         | android_x86_64     | BP     | BP       |           |             |               | android-x86_64       |
-    |         | armv6_static       |        |          | BP        | BP          |               | linux-armv6          |
-    |         | armv6_mixed        | BP     |          |           |             |               | linux-armv6          |
-    |         | armv6_dyn          |        |          | B         | B           |               |                      |
-    |         | armv8_static       |        |          | BP        | BP          |               | linux-armv8          |
-    |         | armv8_mixed        | BP     |          |           |             |               | linux-armv8          |
-    |         | armv8_dyn          |        |          | B         | B           |               |                      |
-    |         | aarch64_static     |        |          | BP        | BP          |               | linux-aarch64        |
-    |         | aarch64_mixed      | BP     |          |           |             |               | linux-aarch64        |
-    |         | aarch64_dyn        | d      |          | B         | B           |               |                      |
-    |         | aarch64_musl_static|        |          | BP        | BP          |               | linux-aarch64-musl   |
-    |         | aarch64_musl_mixed | BP     |          |           |             |               | linux-aarch64-musl   |
-    |         | aarch64_musl_dyn   | d      |          | B         | B           |               |                      |
-    |         | win32_static       | d      | dB       | dBP       | dBP         |               | win-i686             |
-    |         | win32_dyn          | d      | dB       | dB        | dB          |               |                      |
-    |         | i586_static        |        |          | BP        | BP          |               | linux-i586           |
-    |         | i586_dyn           |        |          | B         | B           |               |                      |
-    |         | wasm               | dBP    |          |           |             |               | wasm-emscripten      |
+    |         | android_arm         | dBP    | dBP      |           |             |               | android-arm          |
+    |         | android_arm64       | dBP    | dBP      |           |             |               | android-arm64        |
+    |         | android_x86         | BP     | BP       |           |             |               | android-x86          |
+    |         | android_x86_64      | BP     | BP       |           |             |               | android-x86_64       |
+    |         | armv6_static        |        |          | BP        | BP          |               | linux-armv6          |
+    |         | armv6_mixed         | BP     |          |           |             |               | linux-armv6          |
+    |         | armv6_dyn           |        |          | B         | B           |               |                      |
+    |         | armv8_static        |        |          | BP        | BP          |               | linux-armv8          |
+    |         | armv8_mixed         | BP     |          |           |             |               | linux-armv8          |
+    |         | armv8_dyn           |        |          | B         | B           |               |                      |
+    |         | aarch64_static      |        |          | BP        | BP          |               | linux-aarch64        |
+    |         | aarch64_mixed       | BP     |          |           |             |               | linux-aarch64        |
+    |         | aarch64_dyn         | d      |          | B         | B           |               |                      |
+    |         | aarch64_musl_static |        |          | BP        | BP          |               | linux-aarch64-musl   |
+    |         | aarch64_musl_mixed  | BP     |          |           |             |               | linux-aarch64-musl   |
+    |         | aarch64_musl_dyn    | d      |          | B         | B           |               |                      |
+    |         | win32_static        | d      | dB       | dBP       | dBP         |               | win-i686             |
+    |         | win32_dyn           | d      | dB       | dB        | dB          |               |                      |
+    |         | i586_static         |        |          | BP        | BP          |               | linux-i586           |
+    |         | i586_dyn            |        |          | B         | B           |               |                      |
+    |         | wasm                | dBP    |          |           |             |               | wasm-emscripten      |
 """
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,12 +145,11 @@ jobs:
           - native_static
           - native_mixed
           - iOS_arm64
-          - iOS_x86_64
-          - iOS_Mac_ABI
-          - macOS_arm64_static
-          - macOS_arm64_mixed
-          - macOS_x86_64
-    runs-on: macos-11
+          - iOS_simulator_x86
+          - iOS_simulator_arm64
+          - macOS_arm64
+          - macOS_x86
+    runs-on: macos-13
     env:
       SSH_KEY: /tmp/id_rsa
       OS_NAME: macos

--- a/kiwixbuild/dependencies/libkiwix.py
+++ b/kiwixbuild/dependencies/libkiwix.py
@@ -24,8 +24,6 @@ class Libkiwix(Dependency):
             platformInfo = self.buildEnv.platformInfo
             if platformInfo.build == 'android':
                 return '-Dstatic-linkage=true -Dwerror=false'
-            if platformInfo.build == 'iOS':
-                return '-Db_bitcode=true'
             if platformInfo.name == 'flatpak':
                 return '--wrap-mode=nodownload'
             if platformInfo.mixed and option('target') == 'libkiwix':

--- a/kiwixbuild/dependencies/libzim.py
+++ b/kiwixbuild/dependencies/libzim.py
@@ -30,8 +30,6 @@ class Libzim(Dependency):
             if platformInfo.build == 'android':
                 config_options.append("-DUSE_BUFFER_HEADER=false")
                 config_options.append("-Dstatic-linkage=true")
-            if platformInfo.build == 'iOS':
-                config_options.append("-Db_bitcode=true")
             if platformInfo.mixed and option('target') == 'libzim':
                 config_options.append("-Dstatic-linkage=true")
             if platformInfo.name == "flatpak":


### PR DESCRIPTION
- Removed MacABI (aka UIKit on Mac, it is not needed)
- 5 targets -- iOS_arm64, iOS_simulator_x86, iOS_simulator_arm64, macOS_arm64, macOS_x86
- added `mmacosx-version-min` and `mmacosx-version-min` in various places
- update min os version to macOS 12.0 & iOS 15.0