### PR TITLE
Revert back the libkiwix version to 12.1.1

### DIFF
--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -2,7 +2,7 @@
 
 main_project_versions = {
     'libzim': '8.2.1',
-    'libkiwix': '13.0.0',
+    'libkiwix': '12.1.1',
     'kiwix-tools': '3.5.0',
     'zim-tools': '3.2.0',
     'kiwix-desktop': '2.3.1' # Also change KIWIX_DESKTOP_VERSION and KIWIX_DESKTOP_RELEASE in appveyor.yml


### PR DESCRIPTION
We don't have a version 13.0.0 for libkiwix.
So the master branch of libkiwix is generating version 12.1.1.

We must use the correct version as we try to fix the rpath on macos and we we don't have the right version, we fail because the lib file doesn't exist.