### PR TITLE
Build zim-tools and kiwix-tools on macos-arm64

### DIFF
--- a/.github/scripts/build_definition.py
+++ b/.github/scripts/build_definition.py
@@ -27,7 +27,7 @@ BUILD_DEF = """
     | macos   | native_mixed       | BP     | BP       |           |             |               | macos-x86_64         |
     | macos   | iOS_arm64          | dB     | B        |           |             |               |                      |
     | macos   | iOS_x86_64         | dB     | B        |           |             |               |                      |
-    | macos   | macOS_arm64_static |        |          |           |             |               |                      |
+    | macos   | macOS_arm64_static |        |          | BP        | BP          |               | macos-arm64          |
     | macos   | macOS_arm64_mixed  | BP     | BP       |           |             |               | macos-arm64          |
     | macos   | macOS_x86_64       | B      | B        |           |             |               |                      |
     ----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fix #593
Fix #592 