### PR TITLE
Apple Platforms updates

### DIFF
--- a/.github/scripts/build_definition.py
+++ b/.github/scripts/build_definition.py
@@ -27,7 +27,6 @@ BUILD_DEF = """
     | macos   | native_mixed       | BP     | BP       |           |             |               | macos-x86_64         |
     | macos   | iOS_arm64          | dB     | B        |           |             |               |                      |
     | macos   | iOS_x86_64         | dB     | B        |           |             |               |                      |
-    | macos   | iOS_Mac_ABI        | B      | B        |           |             |               |                      |
     | macos   | macOS_arm64_static |        |          |           |             |               |                      |
     | macos   | macOS_arm64_mixed  | BP     | BP       |           |             |               | macos-arm64          |
     | macos   | macOS_x86_64       | B      | B        |           |             |               |                      |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,6 @@ jobs:
           - native_mixed
           - iOS_arm64
           - iOS_x86_64
-          - iOS_Mac_ABI
           - macOS_arm64_static
           - macOS_arm64_mixed
           - macOS_x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,11 +152,14 @@ jobs:
           - macOS_arm64_static
           - macOS_arm64_mixed
           - macOS_x86_64
-    runs-on: macos-11
+    runs-on: macos-13
     env:
       SSH_KEY: /tmp/id_rsa
       OS_NAME: macos
     steps:
+    - name: Set Xcode version (15.0.1)
+      # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#xcode
+      run: sudo xcode-select -s /Applications/Xcode_15.0.1.app
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Setup python 3.8

--- a/.github/workflows/releaseNigthly.yml
+++ b/.github/workflows/releaseNigthly.yml
@@ -138,7 +138,7 @@ jobs:
           - native_mixed
           - macOS_arm64_static
           - macOS_arm64_mixed
-    runs-on: macos-11
+    runs-on: macos-13
     env:
       SSH_KEY: /tmp/id_rsa
       OS_NAME: macos
@@ -148,6 +148,9 @@ jobs:
       KEYCHAIN_PASSWORD: mysecretpassword
       KEYCHAIN_PROFILE: build-profile
     steps:
+    - name: Set Xcode version (15.0.1)
+      # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#xcode
+      run: sudo xcode-select -s /Applications/Xcode_15.0.1.app
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Setup python 3.8

--- a/kiwixbuild/dependencies/libkiwix.py
+++ b/kiwixbuild/dependencies/libkiwix.py
@@ -24,8 +24,6 @@ class Libkiwix(Dependency):
             platformInfo = self.buildEnv.platformInfo
             if platformInfo.build == 'android':
                 return '-Dstatic-linkage=true -Dwerror=false'
-            if platformInfo.build == 'iOS':
-                return '-Db_bitcode=true'
             if platformInfo.name == 'flatpak':
                 return '--wrap-mode=nodownload'
             if platformInfo.mixed and option('target') == 'libkiwix':

--- a/kiwixbuild/dependencies/libzim.py
+++ b/kiwixbuild/dependencies/libzim.py
@@ -30,8 +30,6 @@ class Libzim(Dependency):
             if platformInfo.build == 'android':
                 config_options.append("-DUSE_BUFFER_HEADER=false")
                 config_options.append("-Dstatic-linkage=true")
-            if platformInfo.build == 'iOS':
-                config_options.append("-Db_bitcode=true")
             if platformInfo.mixed and option('target') == 'libzim':
                 config_options.append("-Dstatic-linkage=true")
             if platformInfo.name == "flatpak":

--- a/kiwixbuild/platforms/ios.py
+++ b/kiwixbuild/platforms/ios.py
@@ -44,14 +44,12 @@ class ApplePlatformInfo(PlatformInfo):
                 '-isysroot', self.root_path,
                 '-arch', self.arch,
                 '-target',  self.target,
-                '-stdlib=libc++'
             ],
             'extra_cflags': [
                 '-fembed-bitcode',
                 '-isysroot', self.root_path,
                 '-arch', self.arch,
                 '-target', self.target,
-                '-stdlib=libc++',
                 *('-I{}'.format(include_dir) for include_dir in self.get_include_dirs())
             ],
             'host_machine': {
@@ -87,7 +85,6 @@ class ApplePlatformInfo(PlatformInfo):
         env['CFLAGS'] = ' '.join(cflags)
         env['CXXFLAGS'] = ' '.join([
             env['CFLAGS'],
-            '-stdlib=libc++',
             '-std=c++11',
             env['CXXFLAGS'],
         ])

--- a/kiwixbuild/platforms/ios.py
+++ b/kiwixbuild/platforms/ios.py
@@ -14,6 +14,7 @@ class ApplePlatformInfo(PlatformInfo):
     target = None
     sdk_name = None
     min_iphoneos_version = None
+    min_macos_version = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -62,11 +63,19 @@ class ApplePlatformInfo(PlatformInfo):
         if self.min_iphoneos_version:
             config['extra_libs'].append('-miphoneos-version-min={}'.format(self.min_iphoneos_version))
             config['extra_cflags'].append('-miphoneos-version-min={}'.format(self.min_iphoneos_version))
+        if self.min_macos_version:
+            config['extra_libs'].append('-mmacosx-version-min={}'.format(self.min_macos_version))
+            config['extra_cflags'].append('-mmacosx-version-min={}'.format(self.min_macos_version))
         return config
 
     def get_env(self):
         env = super().get_env()
-        env['MACOSX_DEPLOYMENT_TARGET'] = '10.15'
+        cflags = [env['CFLAGS']]
+        if self.min_iphoneos_version:
+            cflags.append('-miphoneos-version-min={}'.format(self.min_iphoneos_version))
+        if self.min_macos_version:
+            cflags.append('-mmacosx-version-min={}'.format(self.min_macos_version))
+        env['CFLAGS'] = ' '.join(cflags)
         return env
 
     def set_comp_flags(self, env):
@@ -116,7 +125,7 @@ class iOSArm64(ApplePlatformInfo):
     host = 'arm-apple-darwin'
     target = 'aarch64-apple-ios'
     sdk_name = 'iphoneos'
-    min_iphoneos_version = '13.0'
+    min_iphoneos_version = '15.0'
 
 
 class iOSx64(ApplePlatformInfo):
@@ -125,7 +134,7 @@ class iOSx64(ApplePlatformInfo):
     host = 'x86_64-apple-darwin'
     target = 'x86_64-apple-ios'
     sdk_name = 'iphonesimulator'
-    min_iphoneos_version = '13.0'
+    min_iphoneos_version = '15.0'
 
 
 class iOSMacABI(ApplePlatformInfo):
@@ -134,34 +143,37 @@ class iOSMacABI(ApplePlatformInfo):
     host = 'x86_64-apple-darwin'
     target = 'x86_64-apple-ios14.0-macabi'
     sdk_name = 'macosx'
-    min_iphoneos_version = '14.0'
+    min_iphoneos_version = '15.0'
 
 
 class macOSArm64(ApplePlatformInfo):
     name = 'macOS_arm64_static'
     arch = cpu = 'arm64'
     host = 'aarch64-apple-darwin'
-    target = 'arm64-apple-macos11'
+    target = 'arm64-apple-macos'
     sdk_name = 'macosx'
     min_iphoneos_version = None
+    min_macos_version = '12.0'
 
 
 class macOSArm64Mixed(MixedMixin('macOS_arm64_static'), ApplePlatformInfo):
     name = 'macOS_arm64_mixed'
     arch = cpu = 'arm64'
     host = 'aarch64-apple-darwin'
-    target = 'arm64-apple-macos11'
+    target = 'arm64-apple-macos'
     sdk_name = 'macosx'
     min_iphoneos_version = None
+    min_macos_version = '12.0'
 
 
 class macOSx64(ApplePlatformInfo):
     name = 'macOS_x86_64'
     arch = cpu = 'x86_64'
     host = 'x86_64-apple-darwin'
-    target = 'x86_64-apple-macos10.12'
+    target = 'x86_64-apple-macos'
     sdk_name = 'macosx'
     min_iphoneos_version = None
+    min_macos_version = '12.0'
 
 
 class IOS(MetaPlatformInfo):

--- a/kiwixbuild/platforms/ios.py
+++ b/kiwixbuild/platforms/ios.py
@@ -137,15 +137,6 @@ class iOSx64(ApplePlatformInfo):
     min_iphoneos_version = '15.0'
 
 
-class iOSMacABI(ApplePlatformInfo):
-    name = 'iOS_Mac_ABI'
-    arch = cpu = 'x86_64'
-    host = 'x86_64-apple-darwin'
-    target = 'x86_64-apple-ios14.0-macabi'
-    sdk_name = 'macosx'
-    min_iphoneos_version = '15.0'
-
-
 class macOSArm64(ApplePlatformInfo):
     name = 'macOS_arm64_static'
     arch = cpu = 'arm64'

--- a/kiwixbuild/platforms/ios.py
+++ b/kiwixbuild/platforms/ios.py
@@ -5,6 +5,8 @@ from kiwixbuild.utils import pj, xrun_find
 from .base import PlatformInfo, MetaPlatformInfo, MixedMixin
 
 
+MIN_MACOS_VERSION = '12.0'
+
 class ApplePlatformInfo(PlatformInfo):
     build = 'iOS'
     static = True
@@ -144,7 +146,7 @@ class macOSArm64(ApplePlatformInfo):
     target = 'arm64-apple-macos'
     sdk_name = 'macosx'
     min_iphoneos_version = None
-    min_macos_version = '12.0'
+    min_macos_version = MIN_MACOS_VERSION
 
 
 class macOSArm64Mixed(MixedMixin('macOS_arm64_static'), ApplePlatformInfo):
@@ -154,7 +156,7 @@ class macOSArm64Mixed(MixedMixin('macOS_arm64_static'), ApplePlatformInfo):
     target = 'arm64-apple-macos'
     sdk_name = 'macosx'
     min_iphoneos_version = None
-    min_macos_version = '12.0'
+    min_macos_version = MIN_MACOS_VERSION
 
 
 class macOSx64(ApplePlatformInfo):
@@ -164,7 +166,7 @@ class macOSx64(ApplePlatformInfo):
     target = 'x86_64-apple-macos'
     sdk_name = 'macosx'
     min_iphoneos_version = None
-    min_macos_version = '12.0'
+    min_macos_version = MIN_MACOS_VERSION
 
 
 class IOS(MetaPlatformInfo):

--- a/kiwixbuild/platforms/ios.py
+++ b/kiwixbuild/platforms/ios.py
@@ -40,13 +40,11 @@ class ApplePlatformInfo(PlatformInfo):
             'binaries': self.binaries,
             'exe_wrapper_def': '',
             'extra_libs': [
-                '-fembed-bitcode',
                 '-isysroot', self.root_path,
                 '-arch', self.arch,
                 '-target',  self.target,
             ],
             'extra_cflags': [
-                '-fembed-bitcode',
                 '-isysroot', self.root_path,
                 '-arch', self.arch,
                 '-target', self.target,
@@ -74,7 +72,6 @@ class ApplePlatformInfo(PlatformInfo):
     def set_comp_flags(self, env):
         super().set_comp_flags(env)
         cflags = [
-            '-fembed-bitcode',
             '-isysroot {}'.format(self.root_path),
             '-arch {}'.format(self.arch),
             '-target {}'.format(self.target),

--- a/kiwixbuild/platforms/native.py
+++ b/kiwixbuild/platforms/native.py
@@ -11,8 +11,8 @@ class NativePlatformInfo(PlatformInfo):
         env = super().get_env()
         if neutralEnv('distname') == 'fedora':
             env['QT_SELECT'] = "5-64"
-         if neutralEnv('distname') == 'Darwin':
-            env['CFLAGS'] += ' '.join([env['CFLAGS'], f'-mmacosx-version-min={MIN_MACOS_VERSION}'])
+        if neutralEnv('distname') == 'Darwin':
+            env['CFLAGS'] += f'-mmacosx-version-min={MIN_MACOS_VERSION}'
         return env
 
 

--- a/kiwixbuild/platforms/native.py
+++ b/kiwixbuild/platforms/native.py
@@ -2,7 +2,7 @@ from .base import PlatformInfo, MixedMixin
 
 from kiwixbuild.utils import pj
 from kiwixbuild._global import option, neutralEnv
-
+from kiwixbuild.platforms.ios import MIN_MACOS_VERSION
 
 class NativePlatformInfo(PlatformInfo):
     build = 'native'
@@ -11,6 +11,8 @@ class NativePlatformInfo(PlatformInfo):
         env = super().get_env()
         if neutralEnv('distname') == 'fedora':
             env['QT_SELECT'] = "5-64"
+         if neutralEnv('distname') == 'Darwin':
+            env['CFLAGS'] += ' '.join([env['CFLAGS'], f'-mmacosx-version-min={MIN_MACOS_VERSION}'])
         return env
 
 


### PR DESCRIPTION
This is a redo of #638 that is supposed to be more explicit. It includes:

- now building explicitly on macos13 with Xcode 15.0.1 (for all targets)
- now targeting macOS 12+ and iOS 15+
- removed bitcode as deprecated by Xcode14
- removed `-stdlib` flag as not allowed on Xcode15
- removed `iOSMacABI` that we don't need

Note that I did not rename the targets (contrary to #638). I think it may make sense to but this should be discussed first. It's important kiwix-build maintainers understand clearly the role of each target.