### PR TITLE
Publish projects deps in branch-named folder when outside of main

### DIFF
--- a/.github/scripts/compile_all_deps.py
+++ b/.github/scripts/compile_all_deps.py
@@ -6,13 +6,17 @@ from common import (
     run_kiwix_build,
     make_deps_archive,
     upload,
-    OS_NAME,
     PLATFORM_TARGET,
+    DEV_BRANCH,
 )
 from build_definition import select_build_targets, DEPS
 
 for target in select_build_targets(DEPS):
     run_kiwix_build(target, platform=PLATFORM_TARGET, build_deps_only=True)
     archive_file = make_deps_archive(target=target)
-    upload(archive_file, "ci@tmp.kiwix.org:30022", "/data/tmp/ci")
+    if DEV_BRANCH:
+        destination = "/data/tmp/ci/dev_preview/" + DEV_BRANCH
+    else:
+        destination = "/data/tmp/ci"
+    upload(archive_file, "ci@tmp.kiwix.org:30022", destination)
     os.remove(str(archive_file))


### PR DESCRIPTION
Still publish the deps in the dep_previews directory in case we would like to test it project's CI.

This should avoid conflict (and broken CI) when we try things on kiwix-build CI.