### PR TITLE
Fixed docker workflow trigger

### DIFF
--- a/.github/scripts/build_definition.py
+++ b/.github/scripts/build_definition.py
@@ -130,7 +130,7 @@ def select_build_targets(criteria):
             print(build_order)
             return build_order
 
-    raise "No definition match with current context."
+    raise ValueError("No definition match with current context.")
 
 def get_platform_name():
     from common import PLATFORM_TARGET, OS_NAME
@@ -143,4 +143,4 @@ def get_platform_name():
             name = row["platform_name"]
             return name or None
 
-    raise "No definition match with current context."
+    raise ValueError("No definition match with current context.")

--- a/.github/workflows/releaseNigthly.yml
+++ b/.github/workflows/releaseNigthly.yml
@@ -214,8 +214,7 @@ jobs:
     needs: [Linux]
     runs-on: ubuntu-22.04
     env:
-      PLATFORM_TARGET: LINUX_DOCKER_TRIGGER
-      OS_NAME: LINUX_DOCKER_TRIGGER
+      PLATFORM_TARGET: native_static
     steps:
     - name: Checkout code
       uses: actions/checkout@v3


### PR DESCRIPTION
There is no such thing as a `LINUX_DOCKER_TRIGGER` platform target nor expected OS_NAME.
BuildDefinition expects the docker publish trigger to happen for native_static