### PR TITLE
Add OS_NAME to docker trigger job

### DIFF
--- a/.github/workflows/releaseNigthly.yml
+++ b/.github/workflows/releaseNigthly.yml
@@ -215,6 +215,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       PLATFORM_TARGET: native_static
+      OS_NAME: linux
     steps:
     - name: Checkout code
       uses: actions/checkout@v3


### PR DESCRIPTION
https://github.com/kiwix/kiwix-build/actions/runs/6905519602/job/18788657204 failed due to missing env `OS_NAME`. I thought it was set on the system as other linux jobs don't set it. It's not so it must be passed.