### PR TITLE
CoreKiwix for iOS Simulator

### DIFF
--- a/.github/scripts/build_definition.py
+++ b/.github/scripts/build_definition.py
@@ -26,7 +26,8 @@ BUILD_DEF = """
     | macos   | native_static      |        |          | BP        | BP          |               | macos-x86_64         |
     | macos   | native_mixed       | BP     | BP       |           |             |               | macos-x86_64         |
     | macos   | iOS_arm64          | dB     | dB       |           |             |               |                      |
-    | macos   | iOS_x86_64         | dB     | dB       |           |             |               |                      |
+    | macos   | iOSSimulator_x86_64| dB     | dB       |           |             |               |                      |
+    | macos   | iOSSimulator_arm64 | dB     | dB       |           |             |               |                      |
     | macos   | macOS_arm64_static |        |          | BP        | BP          |               | macos-arm64          |
     | macos   | macOS_arm64_mixed  | BP     | BP       |           |             |               | macos-arm64          |
     | macos   | macOS_x86_64       | B      | B        |           |             |               |                      |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,8 @@ jobs:
           - native_static
           - native_mixed
           - iOS_arm64
-          - iOS_x86_64
+          - iOSSimulator_x86_64
+          - iOSSimulator_arm64
           - macOS_arm64_static
           - macOS_arm64_mixed
           - macOS_x86_64

--- a/kiwixbuild/dependencies/apple_xcframework.py
+++ b/kiwixbuild/dependencies/apple_xcframework.py
@@ -9,7 +9,13 @@ from .base import Dependency, NoopSource, Builder as BaseBuilder
 
 class AppleXCFramework(Dependency):
     name = "apple_xcframework"
-    subPlatformNames = ["macOS_x86_64", "macOS_arm64_static", "iOS_x86_64", "iOS_arm64"]
+    subPlatformNames = [
+        "macOS_x86_64",
+        "macOS_arm64_static",
+        "iOS_arm64",
+        "iOSSimulator_x86_64",
+        "iOSSimulator_arm64",
+    ]
     Source = NoopSource
 
     class Builder(BaseBuilder):
@@ -24,9 +30,17 @@ class AppleXCFramework(Dependency):
             ]
 
         @property
+        def iossimulator_subplatforms(self):
+            return [
+                target
+                for target in self.all_subplatforms
+                if target.startswith("iOSSimulator")
+            ]
+
+        @property
         def ios_subplatforms(self):
             return [
-                target for target in self.all_subplatforms if target.startswith("iOS")
+                target for target in self.all_subplatforms if target.startswith("iOS_")
             ]
 
         @classmethod
@@ -56,13 +70,6 @@ class AppleXCFramework(Dependency):
                 static_ars = [str(f) for f in Path(lib_dir).glob("*.a")]
 
                 # create merged.a from all *.a in install_dir/lib
-                command = [
-                    "libtool",
-                    "-static",
-                    "-o",
-                    "merged.a",
-                    *static_ars
-                ]
                 run_command(command, lib_dir, context)
 
                 # will be included in xcframework
@@ -71,14 +78,14 @@ class AppleXCFramework(Dependency):
 
             return xcf_libs
 
-        def _make_macos_fat(self, context):
-            """create fat merged.a in fake macOS_fat install/lib with macOS archs"""
-            macos_libs = []
-            for target in self.macos_subplatforms:
+        def make_fat_with(self, platforms, folder_name, context):
+            """create fat merged.a in {folder_name} install/lib with {platforms} archs"""
+            libs = []
+            for target in platforms:
                 plt = PlatformInfo.get_platform(target)
-                macos_libs.append(pj(plt.buildEnv.install_dir, "lib", "merged.a"))
+                libs.append(pj(plt.buildEnv.install_dir, "lib", "merged.a"))
 
-            fat_dir = pj(self.buildEnv.build_dir, "macOS_fat")
+            fat_dir = pj(self.buildEnv.build_dir, folder_name)
             os.makedirs(fat_dir, exist_ok=True)
 
             output_merged = pj(fat_dir, "merged.a")
@@ -87,7 +94,7 @@ class AppleXCFramework(Dependency):
                 "-create",
                 "-output",
                 output_merged,
-                *macos_libs
+                *libs
             ]
             run_command(command, self.buildEnv.build_dir, context)
 
@@ -109,5 +116,16 @@ class AppleXCFramework(Dependency):
             xcf_libs = []
             self.command("remove_if_exists", self._remove_if_exists)
             xcf_libs += self.command("merge_libs", self._merge_libs)
-            xcf_libs += self.command("make_macos_fat", self._make_macos_fat)
+            xcf_libs += self.command(
+                "make_macos_fat",
+                self.make_fat_with,
+                self.macos_subplatforms,
+                "macOS_fat",
+            )
+            xcf_libs += self.command(
+                "make_simulator_fat",
+                self.make_fat_with,
+                self.iossimulator_subplatforms,
+                "iOS-simulator_fat",
+            )
             self.command("build_xcframework", self._build_xcframework, xcf_libs)

--- a/kiwixbuild/dependencies/apple_xcframework.py
+++ b/kiwixbuild/dependencies/apple_xcframework.py
@@ -70,6 +70,7 @@ class AppleXCFramework(Dependency):
                 static_ars = [str(f) for f in Path(lib_dir).glob("*.a")]
 
                 # create merged.a from all *.a in install_dir/lib
+                command = ["libtool", "-static", "-o", "merged.a", *static_ars]
                 run_command(command, lib_dir, context)
 
                 # will be included in xcframework
@@ -89,13 +90,7 @@ class AppleXCFramework(Dependency):
             os.makedirs(fat_dir, exist_ok=True)
 
             output_merged = pj(fat_dir, "merged.a")
-            command = [
-                "lipo",
-                "-create",
-                "-output",
-                output_merged,
-                *libs
-            ]
+            command = ["lipo", "-create", "-output", output_merged, *libs]
             run_command(command, self.buildEnv.build_dir, context)
 
             return [output_merged]
@@ -106,8 +101,10 @@ class AppleXCFramework(Dependency):
             command = ["xcodebuild", "-create-xcframework"]
             for lib in xcf_libs:
                 command += [
-                    "-library", lib,
-                    "-headers", pj(ref_plat.buildEnv.install_dir, "include")
+                    "-library",
+                    lib,
+                    "-headers",
+                    pj(ref_plat.buildEnv.install_dir, "include"),
                 ]
             command += ["-output", self.final_path]
             run_command(command, self.buildEnv.build_dir, context)

--- a/kiwixbuild/platforms/ios.py
+++ b/kiwixbuild/platforms/ios.py
@@ -131,11 +131,20 @@ class iOSArm64(ApplePlatformInfo):
     min_iphoneos_version = '15.0'
 
 
-class iOSx64(ApplePlatformInfo):
-    name = 'iOS_x86_64'
+class iOSx64Simulator(ApplePlatformInfo):
+    name = 'iOSSimulator_x86_64'
     arch = cpu = 'x86_64'
     host = 'x86_64-apple-darwin'
-    target = 'x86_64-apple-ios'
+    target = 'x86-apple-ios-simulator'
+    sdk_name = 'iphonesimulator'
+    min_iphoneos_version = '15.0'
+
+
+class iOSArm64Simulator(ApplePlatformInfo):
+    name = 'iOSSimulator_arm64'
+    arch = cpu = 'arm64'
+    host = 'arm-apple-darwin'
+    target = 'aarch64-apple-ios-simulator'
     sdk_name = 'iphonesimulator'
     min_iphoneos_version = '15.0'
 


### PR DESCRIPTION
When we introduced CoreKiwix.xcframework, we made two mistakes:

- We forgot that some devs are on Apple Silicon and did not include arm64 arch for simulator
- We kept the `x86_64-apple-ios` target thinking simulator is a “just” an iOS on x64

This target mistake prevented XCode from finding our lib usable with the Simulator on x64. Not including an arm64 version obviously prevented Silicon-using devs from using the Simulator.

The included libs changes now from

| Name                         | Content                                               |
| ---------------------------- | ----------------------------------------------------- |
| `ios-arm64`                  | All iOS devices are arm64                             |
| `ios-x86_64-simulator`       | Single x64 binary for Simulator                       |
| `macos-arm64_x86_64`         | Fat binary for macOS with both x64 and arm64          |

To

| Name                         | Content                                               |
| ---------------------------- | ----------------------------------------------------- |
| `ios-arm64`                  | All iOS devices are arm64                             |
| `ios-arm64_x86_64-simulator` | Fsat binary for iOS Simulator with both x64 and arm64 |
| `macos-arm64_x86_64`         | Fat binary for macOS with both x64 and arm64          |

## Changes

- `iOSx64` Platforn renamed to `iOSx64Simulator` with its target fixed to `x86-apple-ios-simulator` (was `x86_64-apple-ios`)
- Added platformn `iOSArm64Simulator` for Apple Silicon devs to run Simulator
- `AppleXCFramework` dependency gets two changes: - Depends on all those platforms - `_make_macos_fat()` turned generic and called both for macOS fat binary and iOS Simulator one

Fixes #667

**Note**: this may require a new build of the libkiwix 13.0.0 release. @kelson42 WDYT?