### PR TITLE
[CI] Publish dependencies archives for other project using a name based on arch.

### DIFF
--- a/.github/scripts/build_definition.py
+++ b/.github/scripts/build_definition.py
@@ -135,7 +135,7 @@ def select_build_targets(criteria):
     raise ValueError("No definition match with current context.")
 
 
-def get_platform_name():
+def get_column_value(column_name):
     from common import COMPILE_CONFIG, OS_NAME
 
     context = Context(COMPILE_CONFIG=COMPILE_CONFIG, OS_NAME=OS_NAME)
@@ -143,7 +143,11 @@ def get_platform_name():
     reader = csv.DictReader(strip_array(BUILD_DEF), dialect=TableDialect())
     for row in reader:
         if context.match(row):
-            name = row["platform_name"]
+            name = row[column_name]
             return name or None
 
     raise ValueError("No definition match with current context.")
+
+
+def get_platform_name():
+    return get_column_value("platform_name")

--- a/.github/scripts/build_definition.py
+++ b/.github/scripts/build_definition.py
@@ -15,52 +15,52 @@ import csv, io, re
 # 'D' letter means we trigger the docker forkflow to build the docker image.
 # If a cell contains several letters, all are done.
 BUILD_DEF = """
-    | OS_NAME | COMPILE_CONFIG     | libzim | libkiwix | zim-tools | kiwix-tools | kiwix-desktop | platform_name        |
-    =====================================================================================================================
+    | OS_NAME | COMPILE_CONFIG     | libzim | libkiwix | zim-tools | kiwix-tools | kiwix-desktop | platform_name        | dependency_name        |
+    ==============================================================================================================================================
 # Bionic is a special case as we need to compile libzim on old arch for python
-    | bionic  | native_mixed       | BP     |          |           |             |               | linux-x86_64-bionic  |
-    | bionic  | aarch64_mixed      | BP     |          |           |             |               | linux-aarch64-bionic |
-    --------------------------------------------------------------------------------------------------------------------
+    | bionic  | native_mixed       | BP     |          |           |             |               | linux-x86_64-bionic  |                        |
+    | bionic  | aarch64_mixed      | BP     |          |           |             |               | linux-aarch64-bionic |                        |
+    ----------------------------------------------------------------------------------------------------------------------------------------------
 # Osx builds, build binaries on native_dyn and native_static. On anyother things, build only the libraries
-    | macos   | native_dyn         | d      | d        | dB        | B           |               |                      |
-    | macos   | native_static      |        |          | BP        | BP          |               | macos-x86_64         |
-    | macos   | native_mixed       | BP     | BP       |           |             |               | macos-x86_64         |
-    | macos   | iOS_arm64          | dB     | dB       |           |             |               |                      |
-    | macos   | iOSSimulator_x86_64| dB     | dB       |           |             |               |                      |
-    | macos   | iOSSimulator_arm64 | dB     | dB       |           |             |               |                      |
-    | macos   | macOS_arm64_static |        |          | BP        | BP          |               | macos-arm64          |
-    | macos   | macOS_arm64_mixed  | BP     | BP       |           |             |               | macos-arm64          |
-    | macos   | macOS_x86_64       | B      | B        |           |             |               |                      |
-    | macos   | apple_all_static   |        | BP       |           |             |               | xcframework          |
-    ----------------------------------------------------------------------------------------------
-    |         | flatpak            |        |          |           |             | BP            |                      |
-    |         | native_static      | d      | d        | dBPSD     | dBPSD       |               | linux-x86_64         |
-    |         | native_mixed       | BPS    | BPS      |           |             |               | linux-x86_64         |
-    |         | native_dyn         | d      | d        | dB        | dB          | dBPS          |                      |
+    | macos   | native_dyn         | d      | d        | dB        | B           |               |                      | macos-x86_64-dyn       |
+    | macos   | native_static      |        |          | BP        | BP          |               | macos-x86_64         |                        |
+    | macos   | native_mixed       | BP     | BP       |           |             |               | macos-x86_64         |                        |
+    | macos   | iOS_arm64          | dB     | dB       |           |             |               |                      | ios-arm64-dyn          |
+    | macos   | iOSSimulator_x86_64| dB     | dB       |           |             |               |                      | ios-x86_64-dyn         |
+    | macos   | iOSSimulator_arm64 | B      | B        |           |             |               |                      |                        |
+    | macos   | macOS_arm64_static |        |          | BP        | BP          |               | macos-arm64          |                        |
+    | macos   | macOS_arm64_mixed  | BP     | BP       |           |             |               | macos-arm64          |                        |
+    | macos   | macOS_x86_64       | B      | B        |           |             |               |                      |                        |
+    | macos   | apple_all_static   |        | BP       |           |             |               | xcframework          |                        |
+    ----------------------------------------------------------------------------------------------------------------------------------------------
+    |         | flatpak            |        |          |           |             | BP            |                      |                        |
+    |         | native_static      | d      | d        | dBPSD     | dBPSD       |               | linux-x86_64         | linux-x86_64-static    |
+    |         | native_mixed       | BPS    | BPS      |           |             |               | linux-x86_64         |                        |
+    |         | native_dyn         | d      | d        | dB        | dB          | dBPS          |                      | linux-x86_64-dyn       |
     # libzim CI is building alpine_dyn but not us
-    |         | android_arm        | dBP    | dBP      |           |             |               | android-arm          |
-    |         | android_arm64      | dBP    | dBP      |           |             |               | android-arm64        |
-    |         | android_x86        | BP     | BP       |           |             |               | android-x86          |
-    |         | android_x86_64     | BP     | BP       |           |             |               | android-x86_64       |
-    |         | armv6_static       |        |          | BP        | BP          |               | linux-armv6          |
-    |         | armv6_mixed        | BP     |          |           |             |               | linux-armv6          |
-    |         | armv6_dyn          |        |          | B         | B           |               |                      |
-    |         | armv8_static       |        |          | BP        | BP          |               | linux-armv8          |
-    |         | armv8_mixed        | BP     |          |           |             |               | linux-armv8          |
-    |         | armv8_dyn          |        |          | B         | B           |               |                      |
-    |         | aarch64_static     |        |          | BP        | BP          |               | linux-aarch64        |
-    |         | aarch64_mixed      | BP     |          |           |             |               | linux-aarch64        |
-    |         | aarch64_dyn        | d      |          | B         | B           |               |                      |
-    |         | aarch64_musl_static|        |          | BP        | BP          |               | linux-aarch64-musl   |
-    |         | aarch64_musl_mixed | BP     |          |           |             |               | linux-aarch64-musl   |
-    |         | aarch64_musl_dyn   | d      |          | B         | B           |               |                      |
-    |         | x86-64_musl_static |        |          | BP        | BP          |               | linux-x86_64-musl    |
-    |         | x86-64_musl_mixed  | BP     |          |           |             |               | linux-x86_64-musl    |
-    |         | win32_static       | d      | dB       | dBP       | dBP         |               | win-i686             |
-    |         | win32_dyn          | d      | dB       | dB        | dB          |               |                      |
-    |         | i586_static        |        |          | BP        | BP          |               | linux-i586           |
-    |         | i586_dyn           |        |          | B         | B           |               |                      |
-    |         | wasm               | dBP    |          |           |             |               | wasm-emscripten      |
+    |         | android_arm        | dBP    | dBP      |           |             |               | android-arm          | android-arm            |
+    |         | android_arm64      | dBP    | dBP      |           |             |               | android-arm64        | android-arm64          |
+    |         | android_x86        | BP     | BP       |           |             |               | android-x86          |                        |
+    |         | android_x86_64     | BP     | BP       |           |             |               | android-x86_64       |                        |
+    |         | armv6_static       |        |          | BP        | BP          |               | linux-armv6          |                        |
+    |         | armv6_mixed        | BP     |          |           |             |               | linux-armv6          |                        |
+    |         | armv6_dyn          |        |          | B         | B           |               |                      |                        |
+    |         | armv8_static       |        |          | BP        | BP          |               | linux-armv8          |                        |
+    |         | armv8_mixed        | BP     |          |           |             |               | linux-armv8          |                        |
+    |         | armv8_dyn          |        |          | B         | B           |               |                      |                        |
+    |         | aarch64_static     |        |          | BP        | BP          |               | linux-aarch64        |                        |
+    |         | aarch64_mixed      | BP     |          |           |             |               | linux-aarch64        |                        |
+    |         | aarch64_dyn        | d      |          | B         | B           |               |                      | linux-aarch64-dyn      |
+    |         | aarch64_musl_static|        |          | BP        | BP          |               | linux-aarch64-musl   |                        |
+    |         | aarch64_musl_mixed | BP     |          |           |             |               | linux-aarch64-musl   |                        |
+    |         | aarch64_musl_dyn   | d      |          | B         | B           |               |                      | linux-aarch64-musl-dyn |
+    |         | x86-64_musl_static |        |          | BP        | BP          |               | linux-x86_64-musl    |                        |
+    |         | x86-64_musl_mixed  | BP     |          |           |             |               | linux-x86_64-musl    |                        |
+    |         | win32_static       | d      | dB       | dBP       | dBP         |               | win-i686             |win32-static            |
+    |         | win32_dyn          | d      | dB       | dB        | dB          |               |                      |win32-dyn               |
+    |         | i586_static        |        |          | BP        | BP          |               | linux-i586           |                        |
+    |         | i586_dyn           |        |          | B         | B           |               |                      |                        |
+    |         | wasm               | dBP    |          |           |             |               | wasm-emscripten      | wasm                   |
 """
 
 
@@ -151,3 +151,7 @@ def get_column_value(column_name):
 
 def get_platform_name():
     return get_column_value("platform_name")
+
+
+def get_dependency_archive_name():
+    return get_column_value("dependency_name")

--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -10,7 +10,7 @@ import shutil
 
 import requests
 
-from build_definition import get_platform_name
+from build_definition import get_platform_name, get_dependency_archive_name
 
 from kiwixbuild.dependencies.apple_xcframework import AppleXCFramework
 from kiwixbuild.versions import (
@@ -274,8 +274,8 @@ def filter_install_dir(path):
 # Full: True if we are creating a full archive to be used as cache by kiwix-build (base_deps2_{os}_{config}_{base_deps_version}.tar.xz)
 # Full: False if we are creating a archive to be used as pre-cached dependencies for project's CI (deps2_{os}_{config}_{target}.tar.xz)
 def make_deps_archive(target=None, name=None, full=False):
-    archive_name = name or "deps2_{}_{}_{}.tar.xz".format(
-        OS_NAME, COMPILE_CONFIG, target
+    archive_name = name or "deps_{}_{}.tar.xz".format(
+        get_dependency_archive_name(), target
     )
     print_message("Create archive {}.", archive_name)
     files_to_archive = list(filter_install_dir(INSTALL_DIR))

--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -161,6 +161,7 @@ def run_kiwix_build(
     command.append("--hide-progress")
     command.append("--fast-clone")
     command.append("--assume-packages-installed")
+    command.append("--use-target-arch-name")
     command.extend(["--config", config])
     if build_deps_only:
         command.append("--build-deps-only")

--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -284,8 +284,8 @@ def filter_install_dir(path):
                     yield sub_dir
 
 
-# Full: True if we are creating a full archive to be used as cache by kiwix-build (base_deps2_{os}_{config}_{base_deps_version}.tar.xz)
-# Full: False if we are creating a archive to be used as pre-cached dependencies for project's CI (deps2_{os}_{config}_{target}.tar.xz)
+# Full: True if we are creating a full archive to be used as cache by kiwix-build (base_deps_{os}_{config}_{base_deps_version}.tar.xz)
+# Full: False if we are creating a archive to be used as pre-cached dependencies for project's CI (deps_{config}_{target}.tar.xz)
 def make_deps_archive(target=None, name=None, full=False):
     archive_name = name or "deps_{}_{}.tar.xz".format(
         get_dependency_archive_name(), target

--- a/.github/scripts/ensure_base_deps.py
+++ b/.github/scripts/ensure_base_deps.py
@@ -32,10 +32,10 @@ def download_base_archive(base_name):
     return file_path
 
 
-ARCHIVE_NAME_TEMPLATE = "base_deps2_{os}_{config}_{version}.tar.xz"
+ARCHIVE_NAME_TEMPLATE = "base_deps_{os}_{config}_{version}.tar.xz"
 
 if COMPILE_CONFIG == "flatpak":
-    base_dep_archive_name = "base_deps2_flatpak.tar.xz"
+    base_dep_archive_name = "base_deps_flatpak.tar.xz"
 else:
     base_dep_archive_name = ARCHIVE_NAME_TEMPLATE.format(
         os=OS_NAME,

--- a/actions/dl_deps_archive/.gitignore
+++ b/actions/dl_deps_archive/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/actions/dl_deps_archive/dist/index.js
+++ b/actions/dl_deps_archive/dist/index.js
@@ -30484,7 +30484,6 @@ function addLocalPath(inputPath) {
 async function run() {
   try {
     const base_url = core.getInput("base_url");
-    const os_name = getInput("os_name", process.env["OS_NAME"]);
     const target = core.getInput("target_platform");
     const project = getInput(
       "project",
@@ -30501,11 +30500,11 @@ async function run() {
 
     let archivePath;
     try {
-      const archive_url = `${base_url}/dev_preview/${branch}/deps2_${os_name}_${target}_${project}.tar.xz`;
+      const archive_url = `${base_url}/dev_preview/${branch}/deps_${target}_${project}.tar.xz`;
       process.stdout.write("Downloading " + archive_url + "\n");
       archivePath = await tc.downloadTool(archive_url);
     } catch (error) {
-      const archive_url = `${base_url}/deps2_${os_name}_${target}_${project}.tar.xz`;
+      const archive_url = `${base_url}/deps_${target}_${project}.tar.xz`;
       process.stdout.write("Downloading " + archive_url + "\n");
       archivePath = await tc.downloadTool(archive_url);
     }

--- a/actions/dl_deps_archive/index.js
+++ b/actions/dl_deps_archive/index.js
@@ -18,7 +18,6 @@ function addLocalPath(inputPath) {
 async function run() {
   try {
     const base_url = core.getInput("base_url");
-    const os_name = getInput("os_name", process.env["OS_NAME"]);
     const target = core.getInput("target_platform");
     const project = getInput(
       "project",
@@ -35,11 +34,11 @@ async function run() {
 
     let archivePath;
     try {
-      const archive_url = `${base_url}/dev_preview/${branch}/deps2_${os_name}_${target}_${project}.tar.xz`;
+      const archive_url = `${base_url}/dev_preview/${branch}/deps_${target}_${project}.tar.xz`;
       process.stdout.write("Downloading " + archive_url + "\n");
       archivePath = await tc.downloadTool(archive_url);
     } catch (error) {
-      const archive_url = `${base_url}/deps2_${os_name}_${target}_${project}.tar.xz`;
+      const archive_url = `${base_url}/deps_${target}_${project}.tar.xz`;
       process.stdout.write("Downloading " + archive_url + "\n");
       archivePath = await tc.downloadTool(archive_url);
     }

--- a/kiwixbuild/__init__.py
+++ b/kiwixbuild/__init__.py
@@ -125,6 +125,18 @@ def parse_args():
             "to develop with the cloned sources."
         ),
     )
+    subgroup.add_argument(
+        "--use-target-arch-name",
+        action="store_true",
+        help=(
+            "Name the build directory using the arch name instead of the config name.\n"
+            "Different configs may create binary for the same arch so this option is "
+            "not recommended when working with several config on the same computer.\n"
+            "However, when generating dependencies for other it is better to have a "
+            "directory named using the target instead of the used config.\n"
+            "Intended to be used in CI only."
+        ),
+    )
     options = parser.parse_args()
 
     if not options.android_arch:

--- a/kiwixbuild/__init__.py
+++ b/kiwixbuild/__init__.py
@@ -137,6 +137,9 @@ def parse_args():
             "Intended to be used in CI only."
         ),
     )
+    subgroup.add_argument(
+        "--get-build-dir", action="store_true", help="Print the output directory."
+    )
     options = parser.parse_args()
 
     if not options.android_arch:
@@ -157,4 +160,7 @@ def main():
         builder = FlatpakBuilder()
     else:
         builder = Builder()
-    builder.run()
+    if options.get_build_dir:
+        print(ConfigInfo.get_config(options.config).buildEnv.build_dir)
+    else:
+        builder.run()

--- a/kiwixbuild/buildenv.py
+++ b/kiwixbuild/buildenv.py
@@ -76,9 +76,12 @@ class NeutralEnv:
 
 class BuildEnv:
     def __init__(self, configInfo):
-        build_dir = "BUILD_{}".format(configInfo.name)
         self.configInfo = configInfo
         self.base_build_dir = pj(option("working_dir"), option("build_dir"))
+        build_dir = (
+            configInfo.arch_name if option("use_target_arch_name") else configInfo.name
+        )
+        build_dir = f"BUILD_{build_dir}"
         self.build_dir = pj(self.base_build_dir, build_dir)
         self.install_dir = pj(self.build_dir, "INSTALL")
         self.toolchain_dir = pj(self.build_dir, "TOOLCHAINS")

--- a/kiwixbuild/buildenv.py
+++ b/kiwixbuild/buildenv.py
@@ -36,7 +36,8 @@ class NeutralEnv:
         if _platform == "Windows":
             print(
                 "ERROR: kiwix-build is not intented to run on Windows platform.\n"
-                "It should probably not work, but well, you still can have a try."
+                "It should probably not work, but well, you still can have a try.",
+                file=sys.stderr,
             )
             cont = input("Do you want to continue ? [y/N]")
             if cont.lower() != "y":
@@ -70,7 +71,7 @@ class NeutralEnv:
             if required:
                 sys.exit("ERROR: {} command not found".format(name))
             else:
-                print("WARNING: {} command not found".format(name))
+                print("WARNING: {} command not found".format(name), file=sys.stderr)
                 return ["{}_NOT_FOUND".format(name.upper())]
 
 

--- a/kiwixbuild/configs/android.py
+++ b/kiwixbuild/configs/android.py
@@ -148,6 +148,10 @@ class Android(MetaConfigInfo):
     compatible_hosts = ["fedora", "debian"]
 
     @property
+    def arch_name(self):
+        return "multi-linux-android"
+
+    @property
     def subConfigNames(self):
         return ["android_{}".format(arch) for arch in option("android_arch")]
 

--- a/kiwixbuild/configs/base.py
+++ b/kiwixbuild/configs/base.py
@@ -27,6 +27,10 @@ class ConfigInfo(metaclass=_MetaConfig):
     mixed = False
     libdir = None
 
+    @property
+    def arch_name(self):
+        return self.arch_full
+
     @classmethod
     def get_config(cls, name, targets=None):
         if name not in cls.all_running_configs:

--- a/kiwixbuild/configs/base.py
+++ b/kiwixbuild/configs/base.py
@@ -135,7 +135,6 @@ def MixedMixin(static_name):
         static = False
 
         def add_targets(self, targetName, targets):
-            print(targetName)
             if option("target") == targetName:
                 return super().add_targets(targetName, targets)
             else:

--- a/kiwixbuild/configs/flatpak.py
+++ b/kiwixbuild/configs/flatpak.py
@@ -4,6 +4,7 @@ from kiwixbuild._global import option, neutralEnv
 
 class FlatpakConfigInfo(ConfigInfo):
     name = "flatpak"
+    arch_name = "flatpak"
     build = "flatpak"
     static = ""
     toolchain_names = ["org.kde", "io.qt.qtwebengine"]

--- a/kiwixbuild/configs/ios.py
+++ b/kiwixbuild/configs/ios.py
@@ -25,6 +25,10 @@ class AppleConfigInfo(ConfigInfo):
         self._root_path = None
 
     @property
+    def arch_name(self):
+        return self.target
+
+    @property
     def root_path(self):
         if self._root_path is None:
             command = "xcrun --sdk {} --show-sdk-path".format(self.sdk_name)
@@ -210,6 +214,10 @@ class IOS(MetaConfigInfo):
     compatible_hosts = ["Darwin"]
 
     @property
+    def arch_name(self):
+        return self.name
+
+    @property
     def subConfigNames(self):
         return ["iOS_{}".format(arch) for arch in option("ios_arch")]
 
@@ -224,6 +232,10 @@ class IOS(MetaConfigInfo):
 class AppleStaticAll(MetaConfigInfo):
     name = "apple_all_static"
     compatible_hosts = ["Darwin"]
+
+    @property
+    def arch_name(self):
+        return self.name
 
     @property
     def subConfigNames(self):

--- a/kiwixbuild/configs/native.py
+++ b/kiwixbuild/configs/native.py
@@ -3,6 +3,9 @@ from .base import ConfigInfo, MixedMixin
 from kiwixbuild.utils import pj
 from kiwixbuild._global import option, neutralEnv
 from kiwixbuild.configs.ios import MIN_MACOS_VERSION
+import sysconfig
+import platform
+import sys
 
 
 class NativeConfigInfo(ConfigInfo):
@@ -15,6 +18,12 @@ class NativeConfigInfo(ConfigInfo):
         if neutralEnv("distname") == "Darwin":
             env["CFLAGS"] += f"-mmacosx-version-min={MIN_MACOS_VERSION}"
         return env
+
+    @property
+    def arch_name(self):
+        if sys.platform == "darwin":
+            return f"{platform.machine()}-apple-darwin"
+        return sysconfig.get_platform()
 
 
 class NativeDyn(NativeConfigInfo):

--- a/kiwixbuild/configs/native.py
+++ b/kiwixbuild/configs/native.py
@@ -35,7 +35,7 @@ class NativeDyn(NativeConfigInfo):
 class NativeStatic(NativeConfigInfo):
     name = "native_static"
     static = True
-    compatible_hosts = ["fedora", "debian"]
+    compatible_hosts = ["fedora", "debian", "Darwin"]
 
 
 class NativeMixed(MixedMixin("native_static"), NativeConfigInfo):

--- a/kiwixbuild/configs/neutral.py
+++ b/kiwixbuild/configs/neutral.py
@@ -3,6 +3,7 @@ from .base import ConfigInfo
 
 class NeutralConfigInfo(ConfigInfo):
     name = "neutral"
+    arch_name = "neutral"
     static = ""
     compatible_hosts = ["fedora", "debian", "Darwin"]
 

--- a/kiwixbuild/utils.py
+++ b/kiwixbuild/utils.py
@@ -13,7 +13,9 @@ from collections import namedtuple, defaultdict
 
 from kiwixbuild._global import neutralEnv, option
 
-pj = os.path.join
+
+def pj(*args):
+    return os.path.normpath(os.path.join(*args))
 
 
 COLORS = {

--- a/kiwixbuild/utils.py
+++ b/kiwixbuild/utils.py
@@ -79,7 +79,7 @@ def remove_duplicates(iterable, key_function=None):
 
 
 def get_sha256(path):
-    progress_chars = "/-\|"
+    progress_chars = "/-\\|"
     current = 0
     batch_size = 1024 * 8
     sha256 = hashlib.sha256()
@@ -139,7 +139,7 @@ def download_remote(what, where):
         context = None
     batch_size = 1024 * 8
     extra_args = {"context": context} if sys.version_info >= (3, 4, 3) else {}
-    progress_chars = "/-\|"
+    progress_chars = "/-\\|"
     try:
         with urllib.request.urlopen(what.url, **extra_args) as resource, open(
             file_path, "wb"

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -39,7 +39,7 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = "98"
+base_deps_meta_version = "99"
 
 base_deps_versions = {
     "zlib": "1.2.12",


### PR DESCRIPTION
Until now, we were publishing deps archives using the `{OS}_{CONFIG}` where OS is the name of the system we are building and CONFIG is how we are building (native/cross...; dyn/static).

Now, we are publishing deps using a name `{TARGET_ARCH}_{dyn/static}` so archives are now independent of the system/config we have used to compile dependencies.
(ie building natively on arm and cross compiling to arm from x86_64 is now using the same name)

On top of that, inside the archive, we were using build dir `BUILD_{CONFIG}`. We now have a option to use `BUILD_{TARGET_ARCH}`.
Note that this option should be used only on CI as we start a new build each time.
On a dev usage when we want to test different config (and especially native vs dyn), this option should not be used as different configs could use the same build directory.