### PR TITLE
Do not expect a full working environment when only asking for build dir.

### DIFF
--- a/kiwixbuild/__init__.py
+++ b/kiwixbuild/__init__.py
@@ -154,7 +154,7 @@ def main():
     options = parse_args()
     options.working_dir = os.path.abspath(options.working_dir)
     _global.set_options(options)
-    neutralEnv = buildenv.NeutralEnv()
+    neutralEnv = buildenv.NeutralEnv(options.get_build_dir)
     _global.set_neutralEnv(neutralEnv)
     if options.config == "flatpak":
         builder = FlatpakBuilder()

--- a/kiwixbuild/buildenv.py
+++ b/kiwixbuild/buildenv.py
@@ -8,7 +8,7 @@ from ._global import neutralEnv, option
 
 
 class NeutralEnv:
-    def __init__(self):
+    def __init__(self, dummy_run):
         self.working_dir = option("working_dir")
         self.source_dir = pj(self.working_dir, "SOURCE")
         self.archive_dir = pj(self.working_dir, "ARCHIVE")
@@ -17,6 +17,10 @@ class NeutralEnv:
         for d in (self.source_dir, self.archive_dir, self.toolchain_dir, self.log_dir):
             os.makedirs(d, exist_ok=True)
         self.detect_platform()
+        if dummy_run:
+            # If this is for a dummy run, we will not run anything.
+            # To check for command (and so, don't enforce their presence)
+            return
         self.ninja_command = self._detect_command(
             "ninja", default=[["ninja"], ["ninja-build"]]
         )


### PR DESCRIPTION
Job `Trigger_Docker` is run in a simple environment not configured. So tools as `ninja` are not installed. But we don't care as we just want to trigger a docker build.
But `common` script now start by asking kiwix-build the build dir. kiwix-build must not fail in this case.