### PR TITLE
Forcefully adding libthai.so to kiwix-desktop appimage

### DIFF
--- a/scripts/create_kiwix-desktop_appImage.sh
+++ b/scripts/create_kiwix-desktop_appImage.sh
@@ -23,6 +23,8 @@ cp $INSTALLDIR/$SYSTEMLIBDIR/*.so* $APPDIR/usr/lib
 rm -f $APPDIR/usr/lib/libmagic.so*
 # Copy nss lib (to not conflict with host's ones)
 cp -a /usr/$SYSTEMLIBDIR/nss $APPDIR/usr/lib
+# Copy libthai.so (see kiwix-desktop issue#1016)
+cp -a /usr/$SYSTEMLIBDIR/libthai.so* $APPDIR/usr/lib
 cp $ICONFILE $APPDIR/usr/share/icons/hicolor/48x48/apps/kiwix-desktop.svg
 mkdir -p $APPDIR/usr/share/applications
 cp $DESKTOPFILE $APPDIR/usr/share/applications/kiwix-desktop.desktop


### PR DESCRIPTION
Should fix kiwix/kiwix-desktop#1016

`linuxdeployqt` (the tool used for creating the `kiwix-desktop` appimage) doesn't put `libthai.so` into the appimage as that library has caused problems in the past. The entry for `libthai.so` in the respective ["blacklist"](https://raw.githubusercontent.com/probonopd/AppImages/ac4d7b73bd98be7d14644775e9058d09109b2fa5/excludelist) reads:

>     libthai.so.0
>     # Workaround for:
>     # audacity: /tmp/.mount_AudaciUsFbON/usr/lib/libthai.so.0: version `LIBTHAI_0.1.25' not found (required by /usr/lib64/libpango-1.0.so.0)
>     # on openSUSE Tumbleweed

I verified that the fix produces an appimage that works on an **Ubuntu 22.04** system with the `libthai.so*` files temporarily removed from `/usr/lib/x86_64-linux-gnu` whereas the [official release appimage](http://download.kiwix.org/release/kiwix-desktop/kiwix-desktop_x86_64_2.3.1-4.appimage) reports the same error as described in kiwix/kiwix-desktop#1016 and doesn't start: 

> ./kiwix-desktop_x86_64_2.3.1-4.appimage: error while loading shared libraries: libthai.so.0: cannot open shared object file: No such file or directory

The (fixed) appimage also works without problem on an unmodified **Ubuntu 22.04** (of course, assuming that kiwix/kiwix-desktop#871 doesn't count in the context of this PR).

Note however that I didn't try running the appimage on a system that contains a drastically different version of `libthai.so` - under both **Ubuntu22.04** (**jammy**) which I used for testing and **Ubuntu 20.04** (**focal**) on which I built the appimage the shared library file (in `/usr/lib/x86_64-linux-gnu`) is named `libthai.so.0.3.1` although **jammy**'s package version for `libthai0` strangely reads `0.1.29-1build1` while for **focal** it's `0.1.28-3`.