### PR TITLE
Exclude libgcc and libunwind from linked libraries on Android.

### DIFF
--- a/kiwixbuild/configs/android.py
+++ b/kiwixbuild/configs/android.py
@@ -45,7 +45,11 @@ class AndroidConfigInfo(ConfigInfo):
         return self.ndk_builder.install_path
 
     def get_cross_config(self):
-        extra_libs = ["-llog"]
+        extra_libs = [
+            "-llog",
+            "-Wl,--exclude-libs,libgcc.a",
+            "-Wl,--exclude-libs,libunwind.a",
+        ]
         extra_cflags = [
             "-I{}".format(include_dir) for include_dir in self.get_include_dirs()
         ]


### PR DESCRIPTION
As said in [1], unwinder is linked automatically by Clang and shared library must not re-export it.

ndk after r23 (we are using r21) should do this. Else we must take care to not re-export it.

From [2], we should pass the flags `Wl,--exclude-libs,libgcc.a` and `-Wl,--exclude-libs,libunwind.a` to avoid re-export `_Unwind_Resume` methods.

Fix https://github.com/kiwix/kiwix-android/issues/3661

[1] https://android.googlesource.com/platform/ndk/+/master/docs/BuildSystemMaintainers.md#Unwinding
[2] https://github.com/android/ndk/issues/889#issuecomment-464334469