### PR TITLE
Use version 0.6 for test data

### DIFF
--- a/kiwixbuild/dependencies/zim_testing_suite.py
+++ b/kiwixbuild/dependencies/zim_testing_suite.py
@@ -9,9 +9,9 @@ class ZimTestingSuite(Dependency):
 
     class Source(ReleaseDownload):
         archive = Remotefile(
-            "zim-testing-suite-0.5.tar.gz",
-            "3ffd7e0adf46e9a44cad463f4220d2406a700e95deeff936463be818acf47256",
-            "https://github.com/openzim/zim-testing-suite/releases/download/v0.5/zim-testing-suite-0.5.tar.gz",
+            "zim-testing-suite-0.6.0.tar.gz",
+            "5aa91349a2791c862217b4d2ddd002f08589146ec047f10d5fa1f5fd85d0ea92",
+            "https://github.com/openzim/zim-testing-suite/releases/download/0.6.0/zim-testing-suite-0.6.0.tar.gz",
         )
 
     Builder = NoopBuilder

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -38,8 +38,8 @@ release_versions = {
 
 
 # This is the "version" of the whole base_deps_versions dict.
-# Change this when you change base_deps_versions.
-base_deps_meta_version = "00"
+# Change this when you change base_deps_versions
+base_deps_meta_version = "01"
 
 base_deps_versions = {
     "zlib": "1.2.12",
@@ -60,6 +60,6 @@ base_deps_versions = {
     "qtwebengine": "5.10.1",
     "org.kde": "5.15-21.08",
     "io.qt.qtwebengine": "5.15-21.08",
-    "zim-testing-suite": "0.5",
+    "zim-testing-suite": "0.6.0",
     "emsdk": "3.1.41",
 }


### PR DESCRIPTION
Need a release of zim-testing-suite after openzim/zim-testing-suite#9 is merged.