### PR TITLE
Rebuild libkiwix 13.1.0

### DIFF
--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -29,8 +29,8 @@ main_project_versions = {
 # - set KIWIX_DESKTOP_RELEASE to 0
 
 release_versions = {
-    "libzim": 0,  # Depends of base deps (was 1)
-    "libkiwix": None,  # Depends of libzim (was 3)
+    "libzim": None,  # Depends of base deps (was 0)
+    "libkiwix": 4,  # Depends of libzim (was 3)
     "kiwix-tools": None,  # Depends of libkiwix and libzim (was 2)
     "zim-tools": None,  # Depends of libzim (was 0)
     "kiwix-desktop": None,  # Depends of libkiwix and libzim (was 4)


### PR DESCRIPTION
When releasing libzim and libkiwix, we use config native_mixed with is a mix of static and dynamic linking:

- Dependencies are build as static libraries.
- Released projects (libzim/libkiwix) are build as dynamic libraries, statically linked to dependencies.

This way, we have only one `.so` file which contain all our needed symbols.

However, this logic is "local" to each project.
This mean that libkiwix is linked **statically** to libzim. So libkiwix.so is containing libzim symbols.

But on "java-libkiwix", we are both linking to libzim.so and libkiwix.so. If the version of the (dynamically) used libzim.so is not the same that the version on which we have (statically) linked libkiwix.so, we end with symbols of two different versions being loaded and conflicting.

So let's rebuild libkiwix with last version of libzim to avoid this conflict.

Note this is not a API nor ABI break issue. It is a compilation issue because we do some funky things.