### PR TITLE
Build Xapian on Windows using meson

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-latest
     env:
       OS_NAME: windows
-      COMPILE_CONFIG: native_dyn
+      COMPILE_CONFIG: native_mixed
       HOME: 'C:\\Users\\runneradmin'
     steps:
     - name: Checkout code

--- a/kiwixbuild/configs/native.py
+++ b/kiwixbuild/configs/native.py
@@ -35,10 +35,10 @@ class NativeDyn(NativeConfigInfo):
 class NativeStatic(NativeConfigInfo):
     name = "native_static"
     static = True
-    compatible_hosts = ["fedora", "debian", "Darwin", "almalinux"]
+    compatible_hosts = ["fedora", "debian", "Darwin", "almalinux", "Windows"]
 
 
 class NativeMixed(MixedMixin("native_static"), NativeConfigInfo):
     name = "native_mixed"
     static = False
-    compatible_hosts = ["fedora", "debian", "Darwin", "almalinux"]
+    compatible_hosts = ["fedora", "debian", "Darwin", "almalinux", "Windows"]

--- a/kiwixbuild/dependencies/all_dependencies.py
+++ b/kiwixbuild/dependencies/all_dependencies.py
@@ -14,7 +14,7 @@ class AllBaseDependencies(Dependency):
         @classmethod
         def get_dependencies(cls, configInfo, allDeps):
             if neutralEnv("distname") == "Windows":
-                return ["zlib", "zstd", "icu4c", "zim-testing-suite"]
+                return ["zlib", "zstd", "icu4c", "zim-testing-suite", "xapian-core"]
             if configInfo.build == "wasm" or environ.get("OS_NAME") == "manylinux":
                 return ["zlib", "lzma", "zstd", "icu4c", "xapian-core"]
 

--- a/kiwixbuild/dependencies/icu4c.py
+++ b/kiwixbuild/dependencies/icu4c.py
@@ -39,15 +39,16 @@ class Icu(Dependency):
                 topdir=None,
                 name=self.source_dir,
             )
-            shutil.rmtree(
-                pj(neutralEnv("source_dir"), self.source_dir, "source", "data")
-            )
-            extract_archive(
-                pj(neutralEnv("archive_dir"), self.archive_data.name),
-                pj(neutralEnv("source_dir"), self.source_dir, "source"),
-                topdir="data",
-                name="data",
-            )
+            if platform.system() != "Windows":
+                shutil.rmtree(
+                    pj(neutralEnv("source_dir"), self.source_dir, "source", "data")
+                )
+                extract_archive(
+                    pj(neutralEnv("archive_dir"), self.archive_data.name),
+                    pj(neutralEnv("source_dir"), self.source_dir, "source"),
+                    topdir="data",
+                    name="data",
+                )
             extract_archive(
                 pj(neutralEnv("archive_dir"), self.meson_patch.name),
                 neutralEnv("source_dir"),

--- a/kiwixbuild/dependencies/libzim.py
+++ b/kiwixbuild/dependencies/libzim.py
@@ -23,7 +23,7 @@ class Libzim(Dependency):
         @classmethod
         def get_dependencies(cls, configInfo, allDeps):
             if neutralEnv("distname") == "Windows":
-                return ["zstd", "icu4c", "zim-testing-suite"]
+                return ["zstd", "xapian-core", "icu4c", "zim-testing-suite"]
             deps = ["lzma", "zstd", "xapian-core", "icu4c"]
             if configInfo.name not in ("flatpak", "wasm"):
                 deps.append("zim-testing-suite")
@@ -33,7 +33,6 @@ class Libzim(Dependency):
         def configure_options(self):
             configInfo = self.buildEnv.configInfo
             if neutralEnv("distname") == "Windows":
-                yield "-Dwith_xapian=false"
                 yield "-Dwerror=false"
             if configInfo.build == "android":
                 yield "-DUSE_BUFFER_HEADER=false"

--- a/kiwixbuild/dependencies/libzim.py
+++ b/kiwixbuild/dependencies/libzim.py
@@ -33,6 +33,7 @@ class Libzim(Dependency):
         def configure_options(self):
             configInfo = self.buildEnv.configInfo
             if neutralEnv("distname") == "Windows":
+                yield "-Dwith_xapian_fuller=false"
                 yield "-Dwerror=false"
             if configInfo.build == "android":
                 yield "-DUSE_BUFFER_HEADER=false"

--- a/kiwixbuild/dependencies/xapian.py
+++ b/kiwixbuild/dependencies/xapian.py
@@ -1,4 +1,8 @@
-from .base import Dependency, ReleaseDownload, MakeBuilder
+from .base import (
+    Dependency,
+    ReleaseDownload,
+    MakeBuilder, MesonBuilder
+)
 
 from kiwixbuild.utils import Remotefile
 from kiwixbuild._global import neutralEnv
@@ -8,22 +12,32 @@ class Xapian(Dependency):
     name = "xapian-core"
 
     class Source(ReleaseDownload):
-        archive = Remotefile(
+        src_archive = Remotefile(
             "xapian-core-1.4.23.tar.xz",
-            "30d3518172084f310dab86d262b512718a7f9a13635aaa1a188e61dc26b2288c",
+            "30d3518172084f310dab86d262b512718a7f9a13635aaa1a188e61dc26b2288c"
         )
+        meson_patch = Remotefile(
+            "xapian-core-1.4.23-1_patch.zip",
+            "",
+            "https://public.kymeria.fr/KIWIX/xapian-core-1.4.23-1_patch.zip"
+        )
+        archives = [src_archive, meson_patch]
 
-    class Builder(MakeBuilder):
+#    class Builder(MakeBuilder):
+#        configure_options = [
+#            "--disable-sse",
+#            "--disable-backend-chert",
+#            "--disable-backend-remote",
+#            "--disable-documentation"]
+#        configure_env = {'_format_LDFLAGS': "{env.LDFLAGS} -L{buildEnv.install_dir}/{buildEnv.libprefix}",
+#                         '_format_CXXFLAGS': "{env.CXXFLAGS} -I{buildEnv.install_dir}/include"}
+
+    class Builder(MesonBuilder):
         configure_options = [
-            "--disable-sse",
-            "--disable-backend-chert",
-            "--disable-backend-remote",
-            "--disable-documentation",
+            "-Denable-sse=false",
+            "-Denable-backend-chert=false",
+            "-Denable-backend-remote=false"
         ]
-        configure_env = {
-            "_format_LDFLAGS": "{env.LDFLAGS} -L{buildEnv.install_dir}/{buildEnv.libprefix}",
-            "_format_CXXFLAGS": "{env.CXXFLAGS} -O3 -I{buildEnv.install_dir}/include",
-        }
 
         @classmethod
         def get_dependencies(cls, configInfo, allDeps):

--- a/kiwixbuild/dependencies/xapian.py
+++ b/kiwixbuild/dependencies/xapian.py
@@ -1,8 +1,4 @@
-from .base import (
-    Dependency,
-    ReleaseDownload,
-    MakeBuilder, MesonBuilder
-)
+from .base import Dependency, GitClone, ReleaseDownload, MakeBuilder, MesonBuilder
 
 from kiwixbuild.utils import Remotefile
 from kiwixbuild._global import neutralEnv
@@ -11,26 +7,30 @@ from kiwixbuild._global import neutralEnv
 class Xapian(Dependency):
     name = "xapian-core"
 
-    class Source(ReleaseDownload):
-        src_archive = Remotefile(
-            "xapian-core-1.4.23.tar.xz",
-            "30d3518172084f310dab86d262b512718a7f9a13635aaa1a188e61dc26b2288c"
-        )
-        meson_patch = Remotefile(
-            "xapian-core-1.4.23-1_patch.zip",
-            "",
-            "https://public.kymeria.fr/KIWIX/xapian-core-1.4.23-1_patch.zip"
-        )
-        archives = [src_archive, meson_patch]
+    class Source(GitClone):
+        git_remote = "https://github.com/openzim/xapian-meson.git"
+        git_dir = "xapian-core"
 
-#    class Builder(MakeBuilder):
-#        configure_options = [
-#            "--disable-sse",
-#            "--disable-backend-chert",
-#            "--disable-backend-remote",
-#            "--disable-documentation"]
-#        configure_env = {'_format_LDFLAGS': "{env.LDFLAGS} -L{buildEnv.install_dir}/{buildEnv.libprefix}",
-#                         '_format_CXXFLAGS': "{env.CXXFLAGS} -I{buildEnv.install_dir}/include"}
+    # class Source(ReleaseDownload):
+    #    src_archive = Remotefile(
+    #        "xapian-core-1.4.23.tar.xz",
+    #        "30d3518172084f310dab86d262b512718a7f9a13635aaa1a188e61dc26b2288c"
+    #    )
+    #    meson_patch = Remotefile(
+    #        "xapian-core-1.4.23-1_patch.zip",
+    #        "",
+    #        "https://public.kymeria.fr/KIWIX/xapian-core-1.4.23-1_patch.zip"
+    #    )
+    #    archives = [src_archive, meson_patch]
+
+    #    class Builder(MakeBuilder):
+    #        configure_options = [
+    #            "--disable-sse",
+    #            "--disable-backend-chert",
+    #            "--disable-backend-remote",
+    #            "--disable-documentation"]
+    #        configure_env = {'_format_LDFLAGS': "{env.LDFLAGS} -L{buildEnv.install_dir}/{buildEnv.libprefix}",
+    #                         '_format_CXXFLAGS': "{env.CXXFLAGS} -I{buildEnv.install_dir}/include"}
 
     class Builder(MesonBuilder):
         configure_options = [
@@ -38,6 +38,7 @@ class Xapian(Dependency):
             "-Denable-backend-chert=false",
             "-Denable-backend-remote=false"
         ]
+        subsource_dir = "xapian-core"
 
         @classmethod
         def get_dependencies(cls, configInfo, allDeps):

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -39,7 +39,7 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = "01"
+base_deps_meta_version = "02"
 
 base_deps_versions = {
     "zlib": "1.2.12",
@@ -47,7 +47,7 @@ base_deps_versions = {
     "zstd": "1.5.2",
     "docoptcpp": "0.6.2",
     "uuid": "1.43.4",
-    "xapian-core": "1.4.23",
+    "xapian-core": "1.4.26",
     "mustache": "4.1",
     "pugixml": "1.2",
     "libmicrohttpd": "0.9.76",


### PR DESCRIPTION
This PR build xapian using meson on Windows.

The version of xapian built is a dev version from https://github.com/openzim/xapian-meson.
It is mostly a 1.4.26 version with patches.

This version as some issues:
- Xapian build using meson on Windows have some tests randomly failing. They are deactivated in https://github.com/openzim/xapian-meson/commit/fb7b5559ee4a2663c2572cca15a279004cbf20a6
- Xapian testing fails on macos_dyn (I suspect it is a 1.4.26 bug, not meson related)
- When libzim use flag `Xapian::Compactor::FULLER` on Windows, xapian crashes. The workaround is to not use this flag.

All those issues have to be fix at a time. But let's advance and merge this unperfect PR.
If you have clues on what happening and how to fix the remaining issues, you are more than welcome !!