### PR TITLE
Use gz compression for deps archive.

### DIFF
--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -343,10 +343,10 @@ def filter_install_dir(path):
                     yield sub_dir
 
 
-# Full: True if we are creating a full archive to be used as cache by kiwix-build (base_deps_{os}_{config}_{base_deps_version}.tar.xz)
-# Full: False if we are creating a archive to be used as pre-cached dependencies for project's CI (deps_{config}_{target}.tar.xz)
+# Full: True if we are creating a full archive to be used as cache by kiwix-build (base_deps_{os}_{config}_{base_deps_version}.tar.gz)
+# Full: False if we are creating a archive to be used as pre-cached dependencies for project's CI (deps_{config}_{target}.tar.gz)
 def make_deps_archive(target=None, name=None, full=False):
-    archive_name = name or "deps_{}_{}.tar.xz".format(
+    archive_name = name or "deps_{}_{}.tar.gz".format(
         get_dependency_archive_name(), target
     )
     print_message("Create archive {}.", archive_name)
@@ -395,7 +395,7 @@ def make_deps_archive(target=None, name=None, full=False):
         files_to_archive += SOURCE_DIR.glob("zim-testing-suite-*/*")
 
     archive_file = TMP_DIR / archive_name
-    with tarfile.open(str(archive_file), "w:xz") as tar:
+    with tarfile.open(str(archive_file), "w:gz") as tar:
         for name in set(files_to_archive):
             print(".{}".format(name), flush=True)
             tar.add(str(name), arcname=str(name.relative_to(relative_path)))

--- a/.github/scripts/ensure_base_deps.py
+++ b/.github/scripts/ensure_base_deps.py
@@ -32,10 +32,10 @@ def download_base_archive(base_name):
     return file_path
 
 
-ARCHIVE_NAME_TEMPLATE = "base_deps_{os}_{config}_{version}.tar.xz"
+ARCHIVE_NAME_TEMPLATE = "base_deps_{os}_{config}_{version}.tar.gz"
 
 if COMPILE_CONFIG == "flatpak":
-    base_dep_archive_name = "base_deps_flatpak.tar.xz"
+    base_dep_archive_name = "base_deps_flatpak.tar.gz"
 else:
     base_dep_archive_name = ARCHIVE_NAME_TEMPLATE.format(
         os=OS_NAME,

--- a/actions/dl_deps_archive/index.js
+++ b/actions/dl_deps_archive/index.js
@@ -34,17 +34,17 @@ async function run() {
 
     let archivePath;
     try {
-      const archive_url = `${base_url}/dev_preview/${branch}/deps_${target}_${project}.tar.xz`;
+      const archive_url = `${base_url}/dev_preview/${branch}/deps_${target}_${project}.tar.gz`;
       process.stdout.write("Downloading " + archive_url + "\n");
       archivePath = await tc.downloadTool(archive_url);
     } catch (error) {
-      const archive_url = `${base_url}/deps_${target}_${project}.tar.xz`;
+      const archive_url = `${base_url}/deps_${target}_${project}.tar.gz`;
       process.stdout.write("Downloading " + archive_url + "\n");
       archivePath = await tc.downloadTool(archive_url);
     }
 
     process.stdout.write("Extracting " + archivePath + " to " + extract_dir);
-    const archive_dir = await tc.extractTar(archivePath, extract_dir, "x");
+    const archive_dir = await tc.extractTar(archivePath, extract_dir);
     process.stdout.write("Extracted to " + archive_dir);
   } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
It is a bit of memory waste but a lot of time win (at least on android build)

- Cold android_arm build goes from 51 minutes to 39 minutes
- Cold macos_all_static goes from 1h15 to 1h03
- Warm android_arm build goes from 32 minutes to 26 minutes
- Warm macos_all_static goes from 14 minutes to 8 minutes