### PR TITLE
Do not use base_deps when building releases.

### DIFF
--- a/.github/scripts/ensure_base_deps.py
+++ b/.github/scripts/ensure_base_deps.py
@@ -15,6 +15,7 @@ from common import (
     HOME,
     COMPILE_CONFIG,
     OS_NAME,
+    MAKE_RELEASE,
 )
 
 
@@ -32,29 +33,40 @@ def download_base_archive(base_name):
     return file_path
 
 
-ARCHIVE_NAME_TEMPLATE = "base_deps_{os}_{config}_{version}.tar.gz"
+def get_archive_name():
+    ARCHIVE_NAME_TEMPLATE = "base_deps_{os}_{config}_{version}.tar.gz"
 
-if COMPILE_CONFIG == "flatpak":
-    base_dep_archive_name = "base_deps_flatpak.tar.gz"
-else:
-    base_dep_archive_name = ARCHIVE_NAME_TEMPLATE.format(
+    if COMPILE_CONFIG == "flatpak":
+        return "base_deps_flatpak.tar.gz"
+
+    return ARCHIVE_NAME_TEMPLATE.format(
         os=OS_NAME,
         config=COMPILE_CONFIG,
         version=base_deps_meta_version,
     )
 
-print_message("Getting archive {}", base_dep_archive_name)
-try:
-    local_filename = download_base_archive(base_dep_archive_name)
-    with tarfile.open(local_filename) as f:
-        f.extractall(str(HOME))
-    os.remove(str(local_filename))
-except URLError:
-    if COMPILE_CONFIG == "flatpak":
-        print_message("Cannot get archive. Move on")
+
+def main():
+    base_dep_archive_name = get_archive_name()
+    print_message("Getting archive {}", base_dep_archive_name)
+    try:
+        local_filename = download_base_archive(base_dep_archive_name)
+        with tarfile.open(local_filename) as f:
+            f.extractall(str(HOME))
+        os.remove(str(local_filename))
+    except URLError:
+        if COMPILE_CONFIG == "flatpak":
+            print_message("Cannot get archive. Move on")
+        else:
+            print_message("Cannot get archive. Build dependencies")
+            run_kiwix_build("alldependencies", config=COMPILE_CONFIG)
+            archive_file = make_deps_archive(name=base_dep_archive_name, full=True)
+            upload(archive_file, "ci@tmp.kiwix.org:30022", "/data/tmp/ci")
+            os.remove(str(archive_file))
+
+
+if __name__ == "__main__":
+    if MAKE_RELEASE:
+        print_message("We are building release. Don't download deps archive.")
     else:
-        print_message("Cannot get archive. Build dependencies")
-        run_kiwix_build("alldependencies", config=COMPILE_CONFIG)
-        archive_file = make_deps_archive(name=base_dep_archive_name, full=True)
-        upload(archive_file, "ci@tmp.kiwix.org:30022", "/data/tmp/ci")
-        os.remove(str(archive_file))
+        main()

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -29,7 +29,7 @@ main_project_versions = {
 # - set KIWIX_DESKTOP_RELEASE to 0
 
 release_versions = {
-    "libzim": 0,  # Depends of base deps (was 0)
+    "libzim": 1,  # Depends of base deps (was 0)
     "libkiwix": None,  # Depends of libzim (was 4)
     "kiwix-tools": None,  # Depends of libkiwix and libzim (was 2)
     "zim-tools": None,  # Depends of libzim (was 0)


### PR DESCRIPTION
Initially we were building all our dependencies in release.
This was simply made by always compiling project using autotool or cmake
in release. As our project are using meson/qmake, all the dependencies
are build in release.

However, with recent port to Windows github CI, we have two problems:
- We have moved almost all buildsystem to meson
- On Windows, we cannot mix debug and release build.

So, when doing a release, do not use base dependencies cache.
This will extend the release workflow as we need to build everything but
at least we should build everything correctly.