### PR TITLE
Make nigthly CD build and publish only "publishable" project.

### DIFF
--- a/.github/scripts/build_release_nightly.py
+++ b/.github/scripts/build_release_nightly.py
@@ -21,16 +21,15 @@ from common import (
 from build_definition import select_build_targets, BUILD, PUBLISH, SOURCE_PUBLISH
 
 
+def release_filter(project):
+    return release_versions.get(project) is not None
+
+
 # Filter what to build if we are doing a release.
+TARGETS = select_build_targets(PUBLISH)
+
 if MAKE_RELEASE:
-    TARGETS = select_build_targets(PUBLISH)
-
-    def release_filter(project):
-        return release_versions.get(project) is not None
-
     TARGETS = tuple(filter(release_filter, TARGETS))
-else:
-    TARGETS = select_build_targets(BUILD)
 
 for target in TARGETS:
     run_kiwix_build(target, config=COMPILE_CONFIG, make_release=MAKE_RELEASE)


### PR DESCRIPTION
There is no reason to publish nightly for all project we try to build in the CI.

We should publish nigthly for same project that we do for releases. (Minus the filter of what have changed since last release)

Fix #743