### PR TITLE
[TEMP] Use ci_fix branch of libkiwix

### DIFF
--- a/kiwixbuild/dependencies/libkiwix.py
+++ b/kiwixbuild/dependencies/libkiwix.py
@@ -12,6 +12,7 @@ class Libkiwix(Dependency):
     class Source(GitClone):
         git_remote = "https://github.com/kiwix/libkiwix.git"
         git_dir = "libkiwix"
+        git_ref = "ci_fix"
 
     class Builder(MesonBuilder):
         dependencies = [


### PR DESCRIPTION
This PR is not intended to be merged. Its only purpose is to validate that kiwix/libkiwix#1145 actually fixes kiwix/libkiwix#1143.