### PR TITLE
Bump base_deps_meta_version to rebuild libmicrohttpd

### DIFF
--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -33,7 +33,7 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = "07"
+base_deps_meta_version = "08"
 
 base_deps_versions = {
     "zlib": "1.2.12",


### PR DESCRIPTION
Merging of PR #761 necessitates that the `base_deps` archive for Windows be rebuilt. This is achieved by incrementing `base_deps_meta_version` which will lead to rebuilding of all base dependencies on all platforms.

Once the CI of this PR finishes [base_deps_windows_native_static_08.tar.gz](https://tmp.kiwix.org/ci/base_deps_windows_native_static_08.tar.gz) and its counterparts for other platforms should become available. Then, after this PR is merged, subsequent CI/CD runs will use the new deps archives.