### PR TITLE
Fix missing symbols on CoreKiwix.xcframework

### DIFF
--- a/kiwixbuild/dependencies/libcurl.py
+++ b/kiwixbuild/dependencies/libcurl.py
@@ -23,7 +23,7 @@ class LibCurl(Dependency):
         meson_archive = Remotefile(
             "curl_8.4.0-2_patch.zip",
             "bbb6ae75225c36ef9bb336cface729794c7c070c623a003fff40bd416042ff6e",
-            "https://public.kymeria.fr/KIWIX/curl_8.4.0-2_patch.zip",
+            "https://dev.kiwix.org/libkiwix/curl_8.4.0-2_patch.zip",
         )
         archives = [src_archive, meson_archive]
 

--- a/kiwixbuild/dependencies/libcurl.py
+++ b/kiwixbuild/dependencies/libcurl.py
@@ -33,6 +33,8 @@ class LibCurl(Dependency):
             f"-D{p}=disabled"
             for p in (
                 "psl",
+                "kerberos-auth",
+                "gss-api",
                 "ssh",
                 "ssl",
                 "rtmp",

--- a/kiwixbuild/dependencies/libcurl.py
+++ b/kiwixbuild/dependencies/libcurl.py
@@ -32,6 +32,7 @@ class LibCurl(Dependency):
         configure_options = [
             f"-D{p}=disabled"
             for p in (
+                "psl",
                 "ssh",
                 "ssl",
                 "rtmp",


### PR DESCRIPTION
This fixes the libcurl compilation by explicitly disabling PSL and GSS-API for https://github.com/kiwix/kiwix-apple/issues/984

Note that with this there is still an undefined symbol named  `SCDynamicStoreCopyProxies`.
This is apparently [macOS-specific](https://developer.apple.com/documentation/systemconfiguration/1517088-scdynamicstorecopyproxies) and is fixed by linking (dynamically) to `SystemConfiguration.framework`.

This doesn't seem configurable as this function is used [when `CURL_MACOS_CALL_COPYPROXIES`](https://github.com/curl/curl/blob/master/lib/macos.c) is set but this define is not exposed in config but is [set based on target](https://github.com/curl/curl/blob/master/lib/curl_setup.h#L372).

libcurl did not use/call this function in version 7.67.0 which is the one that was used prior to moving to meson.
