### PR TITLE
Kiwix desktop jammy appimage

### DIFF
--- a/.github/scripts/build_definition.py
+++ b/.github/scripts/build_definition.py
@@ -38,32 +38,32 @@ BUILD_DEF = """
     | macos     | macOS_x86_64       | B      | B        |           |             |               |                         |                        |
     | macos     | apple_all_static   |        | BP       |           |             |               | xcframework             |                        |
     ----------------------------------------------------------------------------------------------------------------------------------------------
-    |           | flatpak            |        |          |           |             | BP            |                         |                        |
-    |           | native_static      | d      | d        | dBPSD     | dBPSD       |               | linux-x86_64            | linux-x86_64-static    |
-    |           | native_mixed       | BPS    | BPS      |           |             |               | linux-x86_64            |                        |
-    |           | native_dyn         | d      | d        | dB        | dB          | dBPS          |                         | linux-x86_64-dyn       |
+    | focal     | flatpak            |        |          |           |             | BP            |                         |                        |
+    | focal     | native_static      | d      | d        | dBPSD     | dBPSD       |               | linux-x86_64            | linux-x86_64-static    |
+    | focal     | native_mixed       | BPS    | BPS      |           |             |               | linux-x86_64            |                        |
+    | focal     | native_dyn         | d      | d        | dB        | dB          | dBPS          |                         | linux-x86_64-dyn       |
     # libzim CI is building alpine_dyn but not us
-    |           | android_arm        | dBP    | dBP      |           |             |               | android-arm             | android-arm            |
-    |           | android_arm64      | dBP    | dBP      |           |             |               | android-arm64           | android-arm64          |
-    |           | android_x86        | BP     | BP       |           |             |               | android-x86             |                        |
-    |           | android_x86_64     | BP     | BP       |           |             |               | android-x86_64          |                        |
-    |           | armv6_static       |        |          | BP        | BP          |               | linux-armv6             |                        |
-    |           | armv6_mixed        | BP     |          |           |             |               | linux-armv6             |                        |
-    |           | armv6_dyn          |        |          | B         | B           |               |                         |                        |
-    |           | armv8_static       |        |          | BP        | BP          |               | linux-armv8             |                        |
-    |           | armv8_mixed        | BP     |          |           |             |               | linux-armv8             |                        |
-    |           | armv8_dyn          |        |          | B         | B           |               |                         |                        |
-    |           | aarch64_static     |        |          | BP        | BP          |               | linux-aarch64           |                        |
-    |           | aarch64_mixed      | BP     |          |           |             |               | linux-aarch64           |                        |
-    |           | aarch64_dyn        | d      |          | B         | B           |               |                         | linux-aarch64-dyn      |
-    |           | aarch64_musl_static|        |          | BP        | BP          |               | linux-aarch64-musl      |                        |
-    |           | aarch64_musl_mixed | BP     |          |           |             |               | linux-aarch64-musl      |                        |
-    |           | aarch64_musl_dyn   | d      |          | B         | B           |               |                         | linux-aarch64-musl-dyn |
-    |           | x86-64_musl_static |        |          | BP        | BP          |               | linux-x86_64-musl       |                        |
-    |           | x86-64_musl_mixed  | BP     |          |           |             |               | linux-x86_64-musl       |                        |
-    |           | i586_static        |        |          | BP        | BP          |               | linux-i586              |                        |
-    |           | i586_dyn           |        |          | B         | B           |               |                         |                        |
-    |           | wasm               | dBP    |          |           |             |               | wasm-emscripten         | wasm                   |
+    | focal     | android_arm        | dBP    | dBP      |           |             |               | android-arm             | android-arm            |
+    | focal     | android_arm64      | dBP    | dBP      |           |             |               | android-arm64           | android-arm64          |
+    | focal     | android_x86        | BP     | BP       |           |             |               | android-x86             |                        |
+    | focal     | android_x86_64     | BP     | BP       |           |             |               | android-x86_64          |                        |
+    | focal     | armv6_static       |        |          | BP        | BP          |               | linux-armv6             |                        |
+    | focal     | armv6_mixed        | BP     |          |           |             |               | linux-armv6             |                        |
+    | focal     | armv6_dyn          |        |          | B         | B           |               |                         |                        |
+    | focal     | armv8_static       |        |          | BP        | BP          |               | linux-armv8             |                        |
+    | focal     | armv8_mixed        | BP     |          |           |             |               | linux-armv8             |                        |
+    | focal     | armv8_dyn          |        |          | B         | B           |               |                         |                        |
+    | focal     | aarch64_static     |        |          | BP        | BP          |               | linux-aarch64           |                        |
+    | focal     | aarch64_mixed      | BP     |          |           |             |               | linux-aarch64           |                        |
+    | focal     | aarch64_dyn        | d      |          | B         | B           |               |                         | linux-aarch64-dyn      |
+    | focal     | aarch64_musl_static|        |          | BP        | BP          |               | linux-aarch64-musl      |                        |
+    | focal     | aarch64_musl_mixed | BP     |          |           |             |               | linux-aarch64-musl      |                        |
+    | focal     | aarch64_musl_dyn   | d      |          | B         | B           |               |                         | linux-aarch64-musl-dyn |
+    | focal     | x86-64_musl_static |        |          | BP        | BP          |               | linux-x86_64-musl       |                        |
+    | focal     | x86-64_musl_mixed  | BP     |          |           |             |               | linux-x86_64-musl       |                        |
+    | focal     | i586_static        |        |          | BP        | BP          |               | linux-i586              |                        |
+    | focal     | i586_dyn           |        |          | B         | B           |               |                         |                        |
+    | focal     | wasm               | dBP    |          |           |             |               | wasm-emscripten         | wasm                   |
 """
 
 

--- a/.github/scripts/build_definition.py
+++ b/.github/scripts/build_definition.py
@@ -41,7 +41,8 @@ BUILD_DEF = """
     | focal     | flatpak            |        |          |           |             | BP            |                         |                        |
     | focal     | native_static      | d      | d        | dBPSD     | dBPSD       |               | linux-x86_64            | linux-x86_64-static    |
     | focal     | native_mixed       | BPS    | BPS      |           |             |               | linux-x86_64            |                        |
-    | focal     | native_dyn         | d      | d        | dB        | dB          | dBPS          |                         | linux-x86_64-dyn       |
+    | focal     | native_dyn         | d      | d        | dB        | dB          |               |                         | linux-x86_64-dyn       |
+    | jammy     | native_dyn         | d      | d        |           |             | dBPS          |                         | linux-x86_64-dyn       |
     # libzim CI is building alpine_dyn but not us
     | focal     | android_arm        | dBP    | dBP      |           |             |               | android-arm             | android-arm            |
     | focal     | android_arm64      | dBP    | dBP      |           |             |               | android-arm64           | android-arm64          |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -131,12 +131,14 @@ jobs:
             image_variant: manylinux
           - config: aarch64_mixed
             image_variant: manylinux
+          - config: native_dyn
+            image_variant: jammy
     env:
       HOME: /home/runner
       SSH_KEY: /tmp/id_rsa
     runs-on: ubuntu-22.04
     container:
-      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2024-06-03"
+      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2024-11-30"
       options: "--device /dev/fuse --privileged"
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
     env:
       HOME: /home/runner
       SSH_KEY: /tmp/id_rsa
+      OS_NAME: ${{matrix.image_variant}}
     runs-on: ubuntu-22.04
     container:
       image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2024-06-03"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,13 +107,15 @@ jobs:
             image_variant: manylinux
           - config: aarch64_mixed
             image_variant: manylinux
+          - config: native_dyn
+            image_variant: jammy
     env:
       HOME: /home/runner
       SSH_KEY: /tmp/id_rsa
       OS_NAME: ${{matrix.image_variant}}
     runs-on: ubuntu-22.04
     container:
-      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2024-06-03"
+      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2024-11-30"
       options: "--device /dev/fuse --privileged"
     steps:
     - name: Checkout code

--- a/scripts/create_kiwix-desktop_appImage.sh
+++ b/scripts/create_kiwix-desktop_appImage.sh
@@ -14,34 +14,32 @@ fi
 ICONFILE=$SOURCEDIR/resources/icons/kiwix/scalable/kiwix-desktop.svg
 DESKTOPFILE=$SOURCEDIR/resources/org.kiwix.desktop.desktop
 
-# Create structure
-mkdir -p $APPDIR/usr/{bin,lib,share} $APPDIR/usr/share/applications $APPDIR/usr/share/icons/hicolor/48x48/apps
-# Copy our files
-cp $INSTALLDIR/bin/kiwix-desktop $APPDIR/usr/bin/
-cp $INSTALLDIR/$SYSTEMLIBDIR/*.so* $APPDIR/usr/lib
-# Remove it as it break with linuxdeployqt (should we compile without it) ?
-rm -f $APPDIR/usr/lib/libmagic.so*
-# Copy nss lib (to not conflict with host's ones)
-cp -a /usr/$SYSTEMLIBDIR/nss $APPDIR/usr/lib
-# Copy libthai.so (see kiwix-desktop issue#1016)
-cp -a /usr/$SYSTEMLIBDIR/libthai.so* $APPDIR/usr/lib
-cp $ICONFILE $APPDIR/usr/share/icons/hicolor/48x48/apps/kiwix-desktop.svg
-mkdir -p $APPDIR/usr/share/applications
-cp $DESKTOPFILE $APPDIR/usr/share/applications/kiwix-desktop.desktop
+# Get linuxdeploy
+wget --continue https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20240109-1/linuxdeploy-x86_64.AppImage
+chmod u+x linuxdeploy-x86_64.AppImage
+wget --continue https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/1-alpha-20240109-1/linuxdeploy-plugin-qt-x86_64.AppImage
+chmod u+x linuxdeploy-plugin-qt-x86_64.AppImage
+
+# Fill with all deps libs and so
+LD_LIBRARY_PATH=$INSTALLDIR/lib/x86_64-linux-gnu ./linuxdeploy-x86_64.AppImage \
+    --plugin=qt \
+    --appdir="$APPDIR" \
+    --executable=$INSTALLDIR/bin/kiwix-desktop \
+    --desktop-file=$DESKTOPFILE \
+    --icon-file=$ICONFILE \
+    --library=/usr/lib/x86_64-linux-gnu/libthai.so.0 \
 
 # get the aria2
 wget --continue https://github.com/q3aql/aria2-static-builds/releases/download/v1.36.0/aria2-1.36.0-linux-gnu-64bit-build1.tar.bz2
 mkdir -p $APPDIR/usr/bin/ && tar -C $APPDIR/usr/bin/ -xf aria2-1.36.0-linux-gnu-64bit-build1.tar.bz2 aria2-1.36.0-linux-gnu-64bit-build1/aria2c --strip-components=1
 mkdir -p $APPDIR/etc/ssl/certs/ && tar -C $APPDIR/etc/ssl/certs/ -xf aria2-1.36.0-linux-gnu-64bit-build1.tar.bz2 aria2-1.36.0-linux-gnu-64bit-build1/ca-certificates.crt --strip-components=1
 
-# Get linuxdeployqt
-# Dispite the 'continuous' in the file name, it IS release 8
-wget --continue https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage -O linuxdeployqt
-chmod u+x linuxdeployqt
-
-# Fill with all deps libs and so
-./linuxdeployqt $APPDIR/usr/bin/kiwix-desktop -bundle-non-qt-libs -extra-plugins=imageformats,iconengines
 # Fix the RPATH of QtWebEngineProcess [TODO] Fill a issue ?
 patchelf --set-rpath '$ORIGIN/../lib' $APPDIR/usr/libexec/QtWebEngineProcess
-# Build the image.
-./linuxdeployqt $APPDIR/usr/share/applications/kiwix-desktop.desktop -bundle-non-qt-libs -extra-plugins=imageformats,iconengines -appimage
+
+mv $APPDIR/{AppRun.wrapped,kiwix-desktop}
+sed -i 's/AppRun\.wrapped/kiwix-desktop/g' $APPDIR/AppRun
+wget --continue https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage
+chmod u+x appimagetool-x86_64.AppImage
+
+./appimagetool-x86_64.AppImage AppDir Kiwix-"$VERSION"-x86_64.AppImage


### PR DESCRIPTION
Fixes kiwix/kiwix-desktop#1219
 
Depends on kiwix/container-images#264

A working appimage was created using the updated `scripts/create_kiwix-desktop_appImage.sh` in a docker container build using the following Dockerfile  `kiwix-build_ci/jammy_builder.dockerfile` introduced by kiwix/container-images#264).