### PR TITLE
Under Windows builds are forced to release mode

### DIFF
--- a/kiwixbuild/dependencies/base.py
+++ b/kiwixbuild/dependencies/base.py
@@ -538,6 +538,9 @@ class MesonBuilder(Builder):
 
     @property
     def build_type(self):
+        if platform.system() == "Windows":
+            return "release"
+
         return "release" if option("make_release") else "debug"
 
     @property

--- a/kiwixbuild/dependencies/kiwix_desktop.py
+++ b/kiwixbuild/dependencies/kiwix_desktop.py
@@ -20,14 +20,14 @@ class KiwixDesktop(Dependency):
         @property
         def make_targets(self):
             if platform.system() == "Windows":
-                yield "release-all" if option("make_release") else "debug-all"
+                yield "release-all"
             else:
                 yield from super().make_targets
 
         @property
         def make_install_targets(self):
             if platform.system() == "Windows":
-                yield "release-install" if option("make_release") else "debug-install"
+                yield "release-install"
             else:
                 yield "install"
 

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -33,7 +33,7 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = "09"
+base_deps_meta_version = "10"
 
 base_deps_versions = {
     "zlib": "1.2.12",


### PR DESCRIPTION
Fixes #757

`base_deps_meta_version` was bumped so that the base dependencies archives for CI workflows are recreated (we need only the Windows flavours of the archives updated but such surgical intervention is not supported).