### PR TITLE
Fix dev.kiwix.org URL for kiwix-build's own deps

### DIFF
--- a/kiwixbuild/utils.py
+++ b/kiwixbuild/utils.py
@@ -28,7 +28,7 @@ COLORS = {
 }
 
 
-REMOTE_PREFIX = "http://mirror.download.kiwix.org/dev/kiwix-build/"
+REMOTE_PREFIX = "https://dev.kiwix.org/kiwix-build/"
 
 
 def which(name):


### PR DESCRIPTION
`download.kiwix.org/dev/` was deprecated long ago ; this uses the correct address: https://dev.kiwix.org/kiwix-build/

- This is a mandatory fix (old URL not working anymore).
- This doesnt change anything.

Already tested in https://github.com/kiwix/kiwix-build/actions/runs/12142381918