### PR TITLE
Fixed a bug in kiwix-desktop's source publishing step

### DIFF
--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -544,7 +544,7 @@ def create_desktop_image(make_release):
     elif platform.system() == "Windows":
         archive_basename = "kiwix-desktop_windows_x64_{}".format(postfix)
         working_dir = INSTALL_DIR / archive_basename
-        build_path = working_dir + ".zip"
+        build_path = Path(str(working_dir) + ".zip")
         app_name = build_path.name
         command = [
             "python",

--- a/kiwixbuild/dependencies/base.py
+++ b/kiwixbuild/dependencies/base.py
@@ -524,8 +524,8 @@ class QMakeBuilder(MakeBuilder):
             *neutralEnv("git_command"),
             "archive",
             "-o",
-            f"{self.build_path}/{self.target_full_name()}.tar.gz",
-            f"--prefix={self.target_full_name()}/",
+            f"{self.build_path}/{self.target.full_name()}.tar.gz",
+            f"--prefix={self.target.full_name()}/",
             "HEAD",
         ]
         run_command(command, self.source_path, context)


### PR DESCRIPTION
The bug was there since 2018. It's strange that it didn't cause problems with previous releases. The most plausible explanation is that this is the first time when the sources of kiwix-desktop are being published via this procedure.

Should fix the issue with the failure of the [Linux (native_dyn, jammy)](https://github.com/kiwix/kiwix-build/actions/runs/12360372427/job/34495187701) job of the `kiwix-desktop` 2.4.0 release workflow run.