### PR TITLE
Support ubuntu jammy, noble, and oracular with their appropriate qt

### DIFF
--- a/kiwixbuild/buildenv.py
+++ b/kiwixbuild/buildenv.py
@@ -42,10 +42,10 @@ class NeutralEnv:
     def detect_platform(self):
         _platform = platform.system()
         self.distname = _platform
+        self.codename = ""
         if _platform == "Linux":
             self.distname = distro.id()
-            if self.distname == "ubuntu":
-                self.distname = "debian"
+            self.codename = distro.codename()
 
     def download(self, what, where=None):
         where = where or self.archive_dir

--- a/kiwixbuild/builder.py
+++ b/kiwixbuild/builder.py
@@ -124,29 +124,32 @@ class Builder:
 
     def _get_packages(self):
         packages_list = []
-        for config in ConfigInfo.all_running_configs.values():
-            mapper_name = "{host}_{config}".format(
-                host=neutralEnv("distname"), config=config
-            )
-            package_name_mapper = PACKAGE_NAME_MAPPERS.get(mapper_name, {})
-            packages_list += package_name_mapper.get("COMMON", [])
+        for runningConfig in ConfigInfo.all_running_configs.values():
+            for mapper_name in self._get_mapper_names_for_config(runningConfig):
+                package_name_mapper = PACKAGE_NAME_MAPPERS.get(mapper_name, {})
+                packages_list += package_name_mapper.get("COMMON", [])
 
         to_drop = []
         for builderDef in self._targets:
-            configName, builderName = builderDef
-            mapper_name = "{host}_{config}".format(
-                host=neutralEnv("distname"), config=configName
-            )
-            package_name_mapper = PACKAGE_NAME_MAPPERS.get(mapper_name, {})
-            packages = package_name_mapper.get(builderName)
-            if packages:
-                to_drop.append(builderDef)
-                if packages is not True:
-                    # True means "assume the dependency is install but do not try to install anything for it"
-                    packages_list += packages
+            builderConfig, builderName = builderDef
+
+            for mapper_name in self._get_mapper_names_for_config(builderConfig):
+                package_name_mapper = PACKAGE_NAME_MAPPERS.get(mapper_name, {})
+                packages = package_name_mapper.get(builderName)
+                if packages:
+                    to_drop.append(builderDef)
+                    if packages is not True:
+                        # True means "assume the dependency is install but do
+                        # not try to install anything for it"
+                        packages_list += packages
+
         for dep in to_drop:
             del self._targets[dep]
         return packages_list
+
+    def _get_mapper_names_for_config(self, config):
+        host = neutralEnv("distname")
+        return ( f"{host}_{config}", )
 
     def install_packages(self):
         packages_to_have = self._get_packages()

--- a/kiwixbuild/builder.py
+++ b/kiwixbuild/builder.py
@@ -149,7 +149,10 @@ class Builder:
 
     def _get_mapper_names_for_config(self, config):
         host = neutralEnv("distname")
-        return ( f"{host}_{config}", )
+        codename = neutralEnv("codename")
+        yield f"{host}_{config}"
+        if codename != "":
+            yield f"{host}_{codename}_{config}"
 
     def install_packages(self):
         packages_to_have = self._get_packages()
@@ -163,7 +166,7 @@ class Builder:
         if distname in ("fedora", "redhat", "centos"):
             package_installer = "sudo dnf install {}"
             package_checker = "rpm -q --quiet {}"
-        elif distname in ("debian", "Ubuntu"):
+        elif distname in ("debian", "ubuntu"):
             package_installer = "sudo apt-get install {}"
             package_checker = 'LANG=C dpkg -s {} 2>&1 | grep Status | grep "ok installed" 1>/dev/null 2>&1'
         elif distname == "Darwin":

--- a/kiwixbuild/configs/android.py
+++ b/kiwixbuild/configs/android.py
@@ -7,7 +7,7 @@ class AndroidConfigInfo(ConfigInfo):
     build = "android"
     static = True
     toolchain_names = ["android-ndk"]
-    compatible_hosts = ["fedora", "debian"]
+    compatible_hosts = ["fedora", "debian", "ubuntu"]
 
     def __str__(self):
         return "android"

--- a/kiwixbuild/configs/armhf.py
+++ b/kiwixbuild/configs/armhf.py
@@ -6,7 +6,7 @@ from kiwixbuild._global import get_target_step
 
 # Base config for arm
 class ArmConfigInfo(ConfigInfo):
-    compatible_hosts = ["fedora", "debian", "almalinux"]
+    compatible_hosts = ["fedora", "debian", "ubuntu", "almalinux"]
 
     def get_cross_config(self):
         return {

--- a/kiwixbuild/configs/flatpak.py
+++ b/kiwixbuild/configs/flatpak.py
@@ -8,7 +8,7 @@ class FlatpakConfigInfo(ConfigInfo):
     build = "flatpak"
     static = ""
     toolchain_names = ["org.kde", "io.qt.qtwebengine"]
-    compatible_hosts = ["debian", "fedora"]
+    compatible_hosts = ["debian", "ubuntu", "fedora"]
 
     def __str__(self):
         return "flatpak"

--- a/kiwixbuild/configs/i586.py
+++ b/kiwixbuild/configs/i586.py
@@ -7,7 +7,7 @@ from kiwixbuild.utils import which, pj
 class I586ConfigInfo(ConfigInfo):
     build = "i586"
     arch_full = "i586-linux-gnu"
-    compatible_hosts = ["fedora", "debian"]
+    compatible_hosts = ["fedora", "debian", "ubuntu"]
 
     def get_cross_config(self):
         return {

--- a/kiwixbuild/configs/musl.py
+++ b/kiwixbuild/configs/musl.py
@@ -5,7 +5,7 @@ from kiwixbuild._global import get_target_step
 
 
 class MuslConfigInfo(ConfigInfo):
-    compatible_hosts = ["fedora", "debian"]
+    compatible_hosts = ["fedora", "debian", "ubuntu"]
 
     def get_cross_config(self):
         return {

--- a/kiwixbuild/configs/native.py
+++ b/kiwixbuild/configs/native.py
@@ -29,16 +29,16 @@ class NativeConfigInfo(ConfigInfo):
 class NativeDyn(NativeConfigInfo):
     name = "native_dyn"
     static = False
-    compatible_hosts = ["fedora", "debian", "Darwin", "almalinux", "Windows"]
+    compatible_hosts = ["fedora", "debian", "ubuntu", "Darwin", "almalinux", "Windows"]
 
 
 class NativeStatic(NativeConfigInfo):
     name = "native_static"
     static = True
-    compatible_hosts = ["fedora", "debian", "Darwin", "almalinux", "Windows"]
+    compatible_hosts = ["fedora", "debian", "ubuntu", "Darwin", "almalinux", "Windows"]
 
 
 class NativeMixed(MixedMixin("native_static"), NativeConfigInfo):
     name = "native_mixed"
     static = False
-    compatible_hosts = ["fedora", "debian", "Darwin", "almalinux", "Windows"]
+    compatible_hosts = ["fedora", "debian", "ubuntu", "Darwin", "almalinux", "Windows"]

--- a/kiwixbuild/configs/neutral.py
+++ b/kiwixbuild/configs/neutral.py
@@ -5,7 +5,7 @@ class NeutralConfigInfo(ConfigInfo):
     name = "neutral"
     arch_name = "neutral"
     static = ""
-    compatible_hosts = ["fedora", "debian", "Darwin"]
+    compatible_hosts = ["fedora", "debian", "ubuntu", "Darwin"]
 
     def __str__(self):
         return "neutral"

--- a/kiwixbuild/configs/wasm.py
+++ b/kiwixbuild/configs/wasm.py
@@ -12,7 +12,7 @@ class WasmConfigInfo(ConfigInfo):
     libdir = "lib"
     # arch_full = 'wasm64-linux'
     toolchain_names = ["emsdk"]
-    compatible_hosts = ["fedora", "debian"]
+    compatible_hosts = ["fedora", "debian", "ubuntu"]
     exe_wrapper_def = ""
 
     def get_cross_config(self):

--- a/kiwixbuild/configs/win64.py
+++ b/kiwixbuild/configs/win64.py
@@ -18,7 +18,7 @@ class Win64ConfigInfo(ConfigInfo):
         "-lkernel32",
     ]
     build = "win64"
-    compatible_hosts = ["fedora", "debian"]
+    compatible_hosts = ["fedora", "debian", "ubuntu"]
     arch_full = "x86_64-w64-mingw32"
 
     def get_cross_config(self):

--- a/kiwixbuild/packages.py
+++ b/kiwixbuild/packages.py
@@ -9,6 +9,7 @@ _fedora_common = [
     "gcc-c++",
     "gettext-devel",
 ]
+
 _debian_common = [
     "automake",
     "libtool",
@@ -20,6 +21,27 @@ _debian_common = [
     "gcc",
     "autopoint",
 ]
+
+_debian_qt5 = {
+    "COMMON": _debian_common + ["libbz2-dev", "libmagic-dev"],
+    "zlib": ["zlib1g-dev"],
+    "uuid": ["uuid-dev"],
+    "libmicrohttpd": ["libmicrohttpd-dev", "ccache"],
+    "qt": ["libqt5gui5", "qtbase5-dev", "qt5-default"],
+    "qtwebengine": ["qtwebengine5-dev"],
+    "aria2": ["aria2"],
+}
+
+_debian_qt6 = {
+    "COMMON": _debian_common,
+    "zlib": ["zlib1g-dev"],
+    "uuid": ["uuid-dev"],
+    "libmicrohttpd": ["libmicrohttpd-dev", "ccache"],
+    "qt": ["qt6-base-dev", "qt6-base-dev-tools", "libqt6webenginecore6-bin", "libqt6svg6", "qtchooser"],
+    "qtwebengine": ["qt6-webengine-dev"],
+    "aria2": ["aria2"],
+}
+
 PACKAGE_NAME_MAPPERS = {
     "flatpak": {
         "zlib": True,
@@ -62,15 +84,7 @@ PACKAGE_NAME_MAPPERS = {
     "fedora_armhf_static": {"COMMON": _fedora_common},
     "fedora_armhf_dyn": {"COMMON": _fedora_common},
     "fedora_android": {"COMMON": _fedora_common},
-    "debian_native_dyn": {
-        "COMMON": _debian_common + ["libbz2-dev", "libmagic-dev"],
-        "zlib": ["zlib1g-dev"],
-        "uuid": ["uuid-dev"],
-        "libmicrohttpd": ["libmicrohttpd-dev", "ccache"],
-        "qt": ["libqt5gui5", "qtbase5-dev", "qt5-default"],
-        "qtwebengine": ["qtwebengine5-dev"],
-        "aria2": ["aria2"],
-    },
+    "debian_native_dyn": _debian_qt5,
     "debian_native_static": {
         "COMMON": _debian_common + ["libbz2-dev", "libmagic-dev"],
     },
@@ -90,6 +104,12 @@ PACKAGE_NAME_MAPPERS = {
     },
     "debian_android": {
         "COMMON": _debian_common,
+    },
+    "ubuntu_jammy_native_dyn":    _debian_qt5,
+    "ubuntu_noble_native_dyn":    _debian_qt6,
+    "ubuntu_oracular_native_dyn": _debian_qt6,
+    "ubuntu_native_static": {
+        "COMMON": _debian_common + ["libbz2-dev", "libmagic-dev"],
     },
     "Darwin_native_dyn": {
         "COMMON": ["autoconf", "automake", "libtool", "cmake", "pkg-config"],

--- a/kiwixbuild/packages.py
+++ b/kiwixbuild/packages.py
@@ -105,8 +105,8 @@ PACKAGE_NAME_MAPPERS = {
     "debian_android": {
         "COMMON": _debian_common,
     },
-    "ubuntu_jammy_native_dyn":    _debian_qt6,
-    "ubuntu_noble_native_dyn":    _debian_qt6,
+    "ubuntu_jammy_native_dyn": _debian_qt6,
+    "ubuntu_noble_native_dyn": _debian_qt6,
     "ubuntu_oracular_native_dyn": _debian_qt6,
     "ubuntu_native_static": {
         "COMMON": _debian_common + ["libbz2-dev", "libmagic-dev"],

--- a/kiwixbuild/packages.py
+++ b/kiwixbuild/packages.py
@@ -105,7 +105,7 @@ PACKAGE_NAME_MAPPERS = {
     "debian_android": {
         "COMMON": _debian_common,
     },
-    "ubuntu_jammy_native_dyn":    _debian_qt5,
+    "ubuntu_jammy_native_dyn":    _debian_qt6,
     "ubuntu_noble_native_dyn":    _debian_qt6,
     "ubuntu_oracular_native_dyn": _debian_qt6,
     "ubuntu_native_static": {


### PR DESCRIPTION
Adds package profiles for various versions of ubuntu - jammy, noble, oracular, and uses their appropriate versions of Qt. 

When specifying packages, you can now use the LSB `codename` in the `PACKAGE_NAME_MAPPERS` dictionary, giving more control about whether (say) a qt package should be installed as version 5 or 6. For example `ubuntu_jammy_native_dyn` and `ubuntu_noble_native_dyn` are now checked to find the package list. Similarly `debian_bookworm_native_dyn` could be used, but I didn't change any existing package lists.