### PR TITLE
Windows build uses Qt 6.4.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
     - name: Install QT
       uses: jurplel/install-qt-action@v4
       with:
-        version: 5.15.2
-        modules: "qtwebengine"
+        version: 6.4.3
+        modules: "qtwebengine qtwebchannel qtpositioning"
         setup-python: false
     - name: Setup MSVC compiler
       uses: bus1/cabuild/action/msdevshell@v1


### PR DESCRIPTION
Once https://github.com/kiwix/kiwix-desktop/pull/1295 is merged, kiwix-build can upgrade to a more recent Qt version. I used 6.4.3 since this is close to the Ubuntu noble version. Its recent without being the newest platform we test on.