### PR TITLE
Fix OS_NAME for Trigger_Docker job in CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -306,7 +306,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       COMPILE_CONFIG: native_static
-      OS_NAME: linux
+      OS_NAME: focal
     steps:
     - name: Checkout code
       uses: actions/checkout@v4


### PR DESCRIPTION
In commit 2321717, OS_NAME was introduced to build_definition in order to support jammy + focal.
The Trigger_Docker job was not updated and was to expecting to run on OS_NAME=linux for which there is now line anymore and thus no possibility to trigger