### PR TITLE
Flatpak uses qt6

### DIFF
--- a/kiwixbuild/dependencies/kiwix_desktop.py
+++ b/kiwixbuild/dependencies/kiwix_desktop.py
@@ -15,7 +15,7 @@ class KiwixDesktop(Dependency):
         dependencies = ["qt", "qtwebengine", "libkiwix", "aria2"]
         configure_env = None
 
-        flatpack_build_options = {"env": {"QMAKEPATH": "/app/lib"}}
+        flatpack_build_options = {"env": {"QMAKEPATH": "/app"}}
 
         @property
         def make_targets(self):

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -50,8 +50,8 @@ base_deps_versions = {
     "libaria2": "1.37.0",
     "libmagic": "5.44",
     "android-ndk": "r21e",
-    "org.kde": "5.15-23.08",
-    "io.qt.qtwebengine": "5.15-23.08",
+    "org.kde": "6.7",
+    "io.qt.qtwebengine": "6.7",
     "zim-testing-suite": "0.6.0",
     "emsdk": "3.1.41",
 }


### PR DESCRIPTION
Upgrades flatpak to 6.7, the older supported flatpak baseapp. The biggest challenge was figuring out that `QMAKEPATH` needed to be `/app` instead of `/app/lib` as it is in the 5.15 line. After [discussing](https://github.com/flathub/io.qt.qtwebengine.BaseApp/issues/375) with the flathub io.qt.webengine.BaseApp folks they added this detail to their main README.