### PR TITLE
Allow to directly access ZIM file (ready-only) in Kiwix Desktop Flatpak

### DIFF
--- a/kiwixbuild/flatpak_builder.py
+++ b/kiwixbuild/flatpak_builder.py
@@ -49,6 +49,7 @@ MANIFEST = {
         "--socket=pulseaudio",
         "--share=network",
         "--share=ipc",
+        "--filesystem=host:ro",
     ],
     "cleanup": [
         "/include",


### PR DESCRIPTION
Fixes https://github.com/kiwix/kiwix-desktop/issues/1310