### PR TITLE
Enable SSL support in libcurl

### DIFF
--- a/kiwixbuild/dependencies/libcurl.py
+++ b/kiwixbuild/dependencies/libcurl.py
@@ -36,7 +36,6 @@ class LibCurl(Dependency):
                 "kerberos-auth",
                 "gss-api",
                 "ssh",
-                "ssl",
                 "rtmp",
                 "http2",
                 "idn",


### PR DESCRIPTION
Should fix kiwix/libkiwix#1180

SSL support has been disabled in our own build of `libcurl` since the very beginning.

One problem with enabling SSL is the CA certificate path that is hardcoded into `libcurl` during the configuration step. Under our Linux build system (Ubuntu) it is set to `/etc/ssl/certs/ca-certificates.crt` but on other distributions of Linux, CA certificates may reside at another location and then https URL won't work.