### PR TITLE
Enabled android-ndk to work with Python 3.12+

### DIFF
--- a/kiwixbuild/dependencies/tc_android_ndk.py
+++ b/kiwixbuild/dependencies/tc_android_ndk.py
@@ -24,6 +24,10 @@ class android_ndk(Dependency):
         def source_dir(self):
             return self.target.full_name()
 
+        patches = [
+            "android-ndk-r21e-linux-x86_64-python3.12+.patch",
+        ]
+
     class Builder(Builder):
         @property
         def install_path(self):

--- a/kiwixbuild/patches/android-ndk-r21e-linux-x86_64-python3.12+.patch
+++ b/kiwixbuild/patches/android-ndk-r21e-linux-x86_64-python3.12+.patch
@@ -1,0 +1,33 @@
+diff -ur android-ndk-r21e/build/tools/make_standalone_toolchain.py android-ndk-r21e.patched/build/tools/make_standalone_toolchain.py
+--- android-ndk-r21e/build/tools/make_standalone_toolchain.py	2025-03-04 20:48:14.681288830 +0400
++++ android-ndk-r21e.patched/build/tools/make_standalone_toolchain.py	2025-03-05 12:10:47.252578915 +0400
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ #
+ # Copyright (C) 2016 The Android Open Source Project
+ #
+@@ -21,7 +21,6 @@
+ """
+ import argparse
+ import atexit
+-from distutils.dir_util import copy_tree
+ import inspect
+ import logging
+ import os
+@@ -221,13 +220,13 @@
+ 
+ def create_toolchain(install_path, arch, api, toolchain_path, host_tag):
+     """Create a standalone toolchain."""
+-    copy_tree(toolchain_path, install_path)
++    shutil.copytree(toolchain_path, install_path)
+     triple = get_triple(arch)
+     make_clang_scripts(install_path, arch, api, host_tag == 'windows-x86_64')
+     replace_gcc_wrappers(install_path, triple, host_tag == 'windows-x86_64')
+ 
+     prebuilt_path = os.path.join(NDK_DIR, 'prebuilt', host_tag)
+-    copy_tree(prebuilt_path, install_path)
++    shutil.copytree(prebuilt_path, install_path, dirs_exist_ok=True)
+ 
+     gdbserver_path = os.path.join(
+         NDK_DIR, 'prebuilt', 'android-' + arch, 'gdbserver')

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -33,7 +33,7 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = "11"
+base_deps_meta_version = "12"
 
 base_deps_versions = {
     "zlib": "1.2.12",


### PR DESCRIPTION
Should fix #808

`distutils` was dropped from Python 3.12. Fortunately, our usage of `android-ndk` only relied on `distutils.dir_util.copy_tree()` in `build/tools/make_standalone_toolchain.py` which
is easy to replace with `shutil.copytree()`. That is done via a small patch.

Note that there are more references to `distutils` in the following files but it looks like our CI/CD flows aren't affected by those:

- `sources/third_party/shaderc/third_party/spirv-tools/utils/generate_registry_tables.py`
- `sources/third_party/vulkan/src/scripts/update_deps.py`
- `prebuilt/linux-x86_64/bin/python2.7-config`
- `prebuilt/linux-x86_64/bin/python-config`
- `prebuilt/linux-x86_64/bin/python2-config`
- various files under `prebuilt/linux-x86_64/lib/python2.7/`
- `python-packages/fastboot/setup.py`
- `python-packages/adb/setup.py`