### PR TITLE
Comment-out ninja install for macOS

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -251,7 +251,7 @@ jobs:
         python-version: '3.10'
     - name: Install packages
       run:
-        brew install ninja automake
+        brew install automake # ninja
     - name: Install python modules
       run: |
         pip3 install meson pytest requests distro

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
         python-version: '3.10'
     - name: Install packages
       run:
-        brew install ninja automake
+        brew install automake # ninja
     - name: Install python modules
       run: |
         pip3 install meson pytest requests distro paramiko


### PR DESCRIPTION
We don't need to install `ninja` anymore because it seems to be part of the base image of the runner. Therefore I have comment-out its installation, also to avoid warnings.