### PR TITLE
QT is installed only in a windows native_mixed job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,6 +37,7 @@ jobs:
         pip3 install meson pytest requests distro paramiko
         pip3 install --no-deps $GITHUB_WORKSPACE
     - name: Install QT
+      if: ${{ matrix.config == 'native_mixed' }}
       uses: jurplel/install-qt-action@v4
       with:
         version: 5.15.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         pip3 install meson pytest requests distro paramiko
         pip3 install --no-deps $GITHUB_WORKSPACE
     - name: Install QT
+      if: ${{ matrix.config == 'native_mixed' }}
       uses: jurplel/install-qt-action@v4
       with:
         version: 6.4.3


### PR DESCRIPTION
`kiwix-desktop` is built under Windows only in `native_mixed` config and QT is not required for anything else. Therefore it doesn't make sense to run QT installation in Windows `native_dyn` and `native_static` CI/CD jobs. That will reduce the risk of those jobs failing because of [problems with QT mirrors](https://github.com/kiwix/kiwix-build/issues/816).