### PR TITLE
Use Gumbo-parser version 0.12.1

### DIFF
--- a/kiwixbuild/dependencies/gumbo.py
+++ b/kiwixbuild/dependencies/gumbo.py
@@ -8,9 +8,9 @@ class Gumbo(Dependency):
 
     class Source(ReleaseDownload):
         archive = Remotefile(
-            "gumbo-0.10.1.tar.gz",
-            "28463053d44a5dfbc4b77bcf49c8cee119338ffa636cc17fc3378421d714efad",
-            "https://github.com/google/gumbo-parser/archive/v0.10.1.tar.gz",
+            "gumbo-parser-0.12.1.tar.gz",
+            "c0bb5354e46539680724d638dbea07296b797229a7e965b13305c930ddc10d82",
+            "https://dev.kiwix.org/kiwix-build/gumbo-parser-0.12.1.tar.gz",
         )
 
         def _post_prepare_script(self, context):

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -33,7 +33,7 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = "12"
+base_deps_meta_version = "13"
 
 base_deps_versions = {
     "zlib": "1.2.12",
@@ -45,7 +45,7 @@ base_deps_versions = {
     "mustache": "4.1",
     "pugixml": "1.2",
     "libmicrohttpd": "0.9.76",
-    "gumbo": "0.10.1",
+    "gumbo": "0.12.1",
     "icu4c": "73.2",
     "libaria2": "1.37.0",
     "libmagic": "5.44",


### PR DESCRIPTION
Gumbo-parser has been forked and has a new maintainer (not Google anymore). Look at https://codeberg.org/gumbo-parser/gumbo-parser/releases

This PR will fix https://github.com/openzim/zim-tools/issues/331