### PR TITLE
Rellocate musl archive

### DIFF
--- a/kiwixbuild/dependencies/tc_musl.py
+++ b/kiwixbuild/dependencies/tc_musl.py
@@ -11,7 +11,8 @@ class aarch64_musl_toolchain(Dependency):
         archive = Remotefile(
             "aarch64-linux-musl-cross.tgz",
             "0f18a885b161815520bbb5757a4b4ab40d0898c29bebee58d0cddd6112e59cc6",
-            "https://more.musl.cc/10/x86_64-linux-musl/aarch64-linux-musl-cross.tgz",
+#            "https://more.musl.cc/10/x86_64-linux-musl/aarch64-linux-musl-cross.tgz",
+             "https://dev.kiwix.org/kiwix-build/aarch64-linux-musl-cross.tgz"
         )
 
     Builder = TcCopyBuilder
@@ -26,7 +27,8 @@ class x86_64_musl_toolchain(Dependency):
         archive = Remotefile(
             "x86_64-linux-musl-cross.tgz",
             "a3d55de8105739fcfb8b10eaa72cdb5d779319726bacff24149388d7608d1ed8",
-            "https://more.musl.cc/10/x86_64-linux-musl/x86_64-linux-musl-cross.tgz",
+#            "https://more.musl.cc/10/x86_64-linux-musl/x86_64-linux-musl-cross.tgz",
+             "https://dev.kiwix.org/kiwix-build/aarch64-linux-musl-cross.tgz"
         )
 
     Builder = TcCopyBuilder

--- a/kiwixbuild/utils.py
+++ b/kiwixbuild/utils.py
@@ -184,7 +184,7 @@ def download_remote(what, where):
                     current = (current + 1) % 4
                 file.write(batch)
     except urllib.error.URLError as e:
-        print("Cannot download url {}:\n{}".format(what.url, e.reason))
+        print("Cannot download URL {}\n{}".format(what.url, e.reason))
         raise StopBuild()
 
     if not what.sha256:

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -23,7 +23,7 @@ main_project_versions = {
 #    - Else, increment the value. If no value was present, see `(was ...)`.
 
 release_versions = {
-    "libzim": 2,  # Depends of base deps (was 1)
+    "libzim": 3,  # Depends of base deps (was 2)
     "libkiwix": None,  # Depends of libzim (was 1)
     "kiwix-tools": None,  # Depends of libkiwix and libzim (was 2)
     "zim-tools": None,  # Depends of libzim (was 0)


### PR DESCRIPTION
Archives should be put in dev.kiwix.org drive. Since a short time it seems that the musl release server block GitHub IPs. See for example https://github.com/kiwix/kiwix-build/actions/runs/15362522826/job/43231415817