### PR TITLE
Use Ubuntu 22.04 (in place of 20.04) for CI/CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -128,7 +128,7 @@ jobs:
           - android_arm64
           - android_x86
           - android_x86_64
-        image_variant: ['focal']
+        image_variant: ['jammy']
         include:
           - config: native_mixed
             image_variant: manylinux
@@ -141,7 +141,7 @@ jobs:
       SSH_KEY: /tmp/id_rsa
     runs-on: ubuntu-22.04
     container:
-      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2024-11-30"
+      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2025-06-06"
       options: "--device /dev/fuse --privileged"
     steps:
     - name: Checkout code
@@ -186,7 +186,7 @@ jobs:
       HOME: /home/runner
       SSH_KEY: /tmp/id_rsa
       COMPILE_CONFIG: flatpak
-      OS_NAME: focal
+      OS_NAME: jammy
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
@@ -309,7 +309,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       COMPILE_CONFIG: native_static
-      OS_NAME: focal
+      OS_NAME: jammy
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           - android_arm64
           - android_x86
           - android_x86_64
-        image_variant: ['focal']
+        image_variant: ['jammy']
         include:
           - config: native_mixed
             image_variant: manylinux
@@ -118,7 +118,7 @@ jobs:
       OS_NAME: ${{matrix.image_variant}}
     runs-on: ubuntu-22.04
     container:
-      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2024-11-30"
+      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2025-06-06"
       options: "--device /dev/fuse --privileged"
     steps:
     - name: Checkout code
@@ -174,7 +174,7 @@ jobs:
       HOME: /home/runner
       SSH_KEY: /tmp/id_rsa
       COMPILE_CONFIG: flatpak
-      OS_NAME: focal
+      OS_NAME: jammy
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout code


### PR DESCRIPTION
* Use Ubuntu 22.04 in place of 20.04 in CI/CD