### PR TITLE
Proper compile configs for macOS (no native_*)

### DIFF
--- a/.github/scripts/build_definition.py
+++ b/.github/scripts/build_definition.py
@@ -27,15 +27,13 @@ BUILD_DEF = """
     | windows   | native_mixed       | BPd    | d        |           |             | BPd           | win-x86_64              | win-x86_64-mixed       |
     ----------------------------------------------------------------------------------------------------------------------------------------------
 # Osx builds, build binaries on native_dyn and native_static. On anyother things, build only the libraries
-    | macos     | native_dyn         | d      | d        | dB        | B           |               |                         | macos-x86_64-dyn       |
-    | macos     | native_static      |        |          | BP        | BP          |               | macos-x86_64            |                        |
-    | macos     | native_mixed       | BP     | BP       |           |             |               | macos-x86_64            |                        |
+    | macos     | macos_x86-64_static|        |          | BP        | BP          |               | macos-x86_64            |                        |
+    | macos     | macos_x86-64_mixed | dBP    | dBP      | d         |             |               | macos-x86_64            | macos-x86_64-dyn       |
     | macos     | ios_arm64          | dB     | dB       |           |             |               |                         | ios-arm64-dyn          |
     | macos     | iossimulator_x86_64| dB     | dB       |           |             |               |                         | ios-x86_64-dyn         |
     | macos     | iossimulator_arm64 | B      | B        |           |             |               |                         |                        |
     | macos     | macos_arm64_static |        |          | BP        | BP          |               | macos-arm64             |                        |
     | macos     | macos_arm64_mixed  | dBP    | dBP      | d         |             |               | macos-arm64             | macos-aarch64-dyn      |
-    | macos     | macos_x86_64       | B      | B        |           |             |               |                         |                        |
     | macos     | apple_all_static   |        | BP       |           |             |               | xcframework             |                        |
     ----------------------------------------------------------------------------------------------------------------------------------------------
     | jammy     | flatpak            |        |          |           |             | BP            |                         |                        |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -225,9 +225,8 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - native_dyn
-          - native_static
-          - native_mixed
+          - macos_x86-64_static
+          - macos_x86-64_mixed
           - macos_arm64_static
           - macos_arm64_mixed
           - apple_all_static

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,15 +214,13 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - native_dyn
-          - native_static
-          - native_mixed
+          - macos_x86-64_static
+          - macos_x86-64_mixed
           - ios_arm64
           - iossimulator_x86_64
           - iossimulator_arm64
           - macos_arm64_static
           - macos_arm64_mixed
-          - macos_x86_64
           - apple_all_static
     runs-on: macos-14
     env:

--- a/kiwixbuild/configs/ios.py
+++ b/kiwixbuild/configs/ios.py
@@ -199,11 +199,21 @@ class macOSArm64Mixed(MixedMixin("macos_arm64_static"), AppleConfigInfo):
     min_macos_version = MIN_MACOS_VERSION
 
 
-class macOSx64(AppleConfigInfo):
-    name = "macos_x86_64"
+class macOSAmd64(AppleConfigInfo):
+    name = "macos_x86-64_static"
     arch = cpu = "x86_64"
     host = "x86_64-apple-darwin"
-    target = "x86_64-apple-macos"
+    target = "x86_64-apple-darwin"
+    sdk_name = "macosx"
+    min_iphoneos_version = None
+    min_macos_version = MIN_MACOS_VERSION
+
+
+class macOSAmd64Mixed(MixedMixin("macos_x86-64_static"), AppleConfigInfo):
+    name = "macos_x86-64_mixed"
+    arch = cpu = "x86_64"
+    host = "x86_64-apple-darwin"
+    target = "x86_64-apple-darwin"
     sdk_name = "macosx"
     min_iphoneos_version = None
     min_macos_version = MIN_MACOS_VERSION

--- a/kiwixbuild/dependencies/apple_xcframework.py
+++ b/kiwixbuild/dependencies/apple_xcframework.py
@@ -10,7 +10,7 @@ from .base import Dependency, NoopSource, Builder as BaseBuilder
 class AppleXCFramework(Dependency):
     name = "apple_xcframework"
     subConfigNames = [
-        "macos_x86_64",
+        "macos_x86-64_static",
         "macos_arm64_static",
         "ios_arm64",
         "iossimulator_x86_64",


### PR DESCRIPTION
With this we stop using `native_*` compile configs on macOS.

- macos_x86-64_static
- macos_x86-64_mixed
- macos_arm64_static
- macos_arm64_mixed

It is important to note that it is urgent to fix the following two tickets because
tests in libkiwix and zim-tools both uses the deprecated API.
With libkiwix now being libkiwix and not kiwixlib, building older versions
is more difficult.

- https://github.com/kiwix/libkiwix/issues/1225
- https://github.com/openzim/zim-tools/issues/475

Fixes https://github.com/kiwix/kiwix-build/issues/841