### PR TITLE
Fixed base_deps for apple_all_static

### DIFF
--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -444,6 +444,7 @@ def make_deps_archive(target=None, name=None, full=False):
         files_to_archive += get_build_dir("native_static").glob("*/.*_ok")
         files_to_archive += HOME.glob("BUILD_*android*/**/.*_ok")
         files_to_archive += HOME.glob("BUILD_*apple-macos*/**/.*_ok")
+        files_to_archive += HOME.glob("BUILD_*apple-darwin*/**/.*_ok")
         files_to_archive += HOME.glob("BUILD_*apple-ios*/**/.*_ok")
         files_to_archive += SOURCE_DIR.glob("*/.*_ok")
         files_to_archive += SOURCE_DIR.glob("zim-testing-suite-*/*")


### PR DESCRIPTION
When we merged #850, it was followed by an [issue](https://github.com/kiwix/kiwix-build/actions/runs/18040483724/job/52043376783) because in-PR CD built the dependencies locally and uploaded it but we did not test (run again) the uploaded base_deps.

The problem was that with name change, we were not including in the base_deps the `.{step}_ok` special files that informs kiwix-build to skip those steps (configure, compile, install, test) and was thus failing to configure the first dependency (pugixml) because it did not contain the meson file (supposed to be an empty folder with just those special files).

For this PR, I deleted the macos-15 base deps and [ran it twice](https://github.com/kiwix/kiwix-build/actions/runs/18282882068/) to confirm it's properly fixed.

Fixes #852 