### PR TITLE
Really force memory pagesize to 16KB on Android

### DIFF
--- a/kiwixbuild/configs/android.py
+++ b/kiwixbuild/configs/android.py
@@ -49,6 +49,7 @@ class AndroidConfigInfo(ConfigInfo):
             "-llog",
             "-Wl,--exclude-libs,libgcc.a",
             "-Wl,--exclude-libs,libunwind.a",
+            "-Wl,-z,max-page-size=16384",
         ]
         extra_cflags = [
             "-I{}".format(include_dir) for include_dir in self.get_include_dirs()
@@ -99,7 +100,7 @@ class AndroidConfigInfo(ConfigInfo):
             )
             + env["CXXFLAGS"]
         )
-        env["LDFLAGS"] = "-Wl,-z,max-page-size=16384 -Wl,-z,common-page-size=16384 --sysroot={} {} ".format(root_path, march) + env["LDFLAGS"]
+        env["LDFLAGS"] = "-Wl,-z,max-page-size=16384 --sysroot={} {} ".format(root_path, march) + env["LDFLAGS"]
 
     def set_compiler(self, env):
         binaries = self.binaries()


### PR DESCRIPTION
Android builds in our CI/CD are done via cross-compilation, so the compiler (including linker) flags actually come via cross compilation configuration.

Also, as we have switched to a newer NDK (from r21e to r23) since the [original attempt to fix the page size](https://github.com/kiwix/kiwix-build/pull/849), we no longer need to set the common-page-size linker option (see https://developer.android.com/guide/practices/page-sizes#compile-r26-lower)

Should fix kiwix/java-libkiwix#119

The page-size has been verified for both `libzim.so` and `libkiwix.so` in a local build for the `android_x86_64` configuration.