### PR TITLE
Update uuid from 1.43.4 to 1.47.3

### DIFF
--- a/kiwixbuild/dependencies/uuid.py
+++ b/kiwixbuild/dependencies/uuid.py
@@ -8,11 +8,11 @@ class UUID(Dependency):
 
     class Source(ReleaseDownload):
         archive = Remotefile(
-            "e2fsprogs-libs-1.43.4.tar.gz",
-            "eed4516325768255c9745e7b82c9d7d0393abce302520a5b2cde693204b0e419",
-            "https://www.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.43.4/e2fsprogs-libs-1.43.4.tar.gz",
+            "e2fsprogs-libs-1.47.3.tar.gz",
+            "7d4612f4e4f7ca6c2f669679028bcb02763e3b6280c9c19b2cf168eaf65e88af",
+            "https://www.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.47.3/e2fsprogs-1.47.3.tar.gz",
         )
-        extract_dir = "e2fsprogs-libs-1.43.4"
+        extract_dir = "e2fsprogs-libs-1.47.3"
 
     class Builder(MakeBuilder):
         configure_options = [
@@ -23,6 +23,7 @@ class UUID(Dependency):
             "--disable-defrag",
             "--enable-fsck",
             "--disable-uuidd",
+            "--enable-subset",
         ]
         configure_env = {"_format_CFLAGS": "{env.CFLAGS} -O3 -fPIC -Wno-error=implicit-function-declaration"}
         static_configure_options = dynamic_configure_options = []

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -33,14 +33,14 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = "17"
+base_deps_meta_version = "18"
 
 base_deps_versions = {
     "zlib": "1.3.1",
     "lzma": "5.2.6",
     "zstd": "1.5.2",
     "docoptcpp": "0.6.2",
-    "uuid": "1.43.4",
+    "uuid": "1.47.3",
     "xapian-core": "1.4.26",
     "mustache": "4.1",
     "pugixml": "1.15",


### PR DESCRIPTION
Addresses #873 
Hey I compiled and checked this does not seem to break anything on android.
Also upstream stopped packaging the libs library separately and combined it into one tar.
It added the --enable-subset flag to include the libs library
https://e2fsprogs.sourceforge.net/e2fsprogs-release.html#1.44.4

> Instead of building the subset e2fsprogs-libs tar file, add a new configure option, --enable-subset. This along with other changes (such as dropping obsolete files that aren't shipped as part of e2fsprogs-X.YY.tar.gz) allows us to be able to build the tarball using the "git archive" command.