### PR TITLE
Move dependency versions into Dependency classes (#877)

### DIFF
--- a/kiwixbuild/dependencies/docoptcpp.py
+++ b/kiwixbuild/dependencies/docoptcpp.py
@@ -5,6 +5,7 @@ from kiwixbuild._global import neutralEnv
 
 class docoptcpp(Dependency):
     name = "docoptcpp"
+    version="0.6.2"
 
     class Source(ReleaseDownload):
         name = "docoptcpp"

--- a/kiwixbuild/dependencies/gumbo.py
+++ b/kiwixbuild/dependencies/gumbo.py
@@ -5,6 +5,7 @@ from kiwixbuild.utils import Remotefile
 
 class Gumbo(Dependency):
     name = "gumbo"
+    version = "0.13.1"
 
     class Source(ReleaseDownload):
         archive = Remotefile(

--- a/kiwixbuild/dependencies/icu4c.py
+++ b/kiwixbuild/dependencies/icu4c.py
@@ -15,6 +15,7 @@ if platform.system() == "Windows":
 
     class Icu(Dependency):
         name = "icu4c"
+        version = "73.2"
 
         class Source(ReleaseDownload):
             archive = Remotefile(

--- a/kiwixbuild/dependencies/libmagic.py
+++ b/kiwixbuild/dependencies/libmagic.py
@@ -12,6 +12,7 @@ from kiwixbuild._global import get_target_step
 
 class LibMagic(Dependency):
     name = "libmagic"
+    version = "5.44"
 
     class Source(ReleaseDownload):
         name = "libmagic"

--- a/kiwixbuild/dependencies/libmicrohttpd.py
+++ b/kiwixbuild/dependencies/libmicrohttpd.py
@@ -5,6 +5,7 @@ from kiwixbuild.utils import Remotefile
 
 class MicroHttpd(Dependency):
     name = "libmicrohttpd"
+    version = "0.9.76"
 
     class Source(ReleaseDownload):
         src_archive = Remotefile(

--- a/kiwixbuild/dependencies/lzma.py
+++ b/kiwixbuild/dependencies/lzma.py
@@ -8,6 +8,7 @@ from kiwixbuild.utils import Remotefile
 
 class lzma(Dependency):
     name = 'lzma'
+    version = "5.2.6"
 
     class Source(ReleaseDownload):
         src_archive = Remotefile(

--- a/kiwixbuild/dependencies/mustache.py
+++ b/kiwixbuild/dependencies/mustache.py
@@ -6,6 +6,7 @@ from shutil import copy2
 
 class Mustache(Dependency):
     name = "mustache"
+    version = "4.1"
 
     class Source(ReleaseDownload):
         archive = Remotefile(

--- a/kiwixbuild/dependencies/pugixml.py
+++ b/kiwixbuild/dependencies/pugixml.py
@@ -5,6 +5,7 @@ from kiwixbuild.utils import Remotefile
 
 class Pugixml(Dependency):
     name = "pugixml"
+    version = "1.15"
 
     class Source(ReleaseDownload):
         archive = Remotefile(

--- a/kiwixbuild/dependencies/tc_android_ndk.py
+++ b/kiwixbuild/dependencies/tc_android_ndk.py
@@ -10,6 +10,7 @@ class android_ndk(Dependency):
     dont_skip = True
     neutral = False
     name = "android-ndk"
+    version = "r23c"
     gccver = "4.9.x"
     api = "24"
 

--- a/kiwixbuild/dependencies/tc_emsdk.py
+++ b/kiwixbuild/dependencies/tc_emsdk.py
@@ -10,6 +10,7 @@ class emsdk(Dependency):
     dont_skip = True
     neutral = False
     name = "emsdk"
+    version = "3.1.41"
 
     class Source(ReleaseDownload):
         archive = Remotefile(

--- a/kiwixbuild/dependencies/tc_flatpak.py
+++ b/kiwixbuild/dependencies/tc_flatpak.py
@@ -9,6 +9,7 @@ pj = os.path.join
 class org_kde(Dependency):
     neutral = False
     name = "org.kde"
+    version ="6.9"
 
     Source = NoopSource
 
@@ -52,6 +53,7 @@ class org_kde(Dependency):
 class io_qt_qtwebengine(Dependency):
     neutral = False
     name = "io.qt.qtwebengine"
+    version = "6.9"
 
     Source = NoopSource
 

--- a/kiwixbuild/dependencies/uuid.py
+++ b/kiwixbuild/dependencies/uuid.py
@@ -5,6 +5,7 @@ from kiwixbuild.utils import Remotefile
 
 class UUID(Dependency):
     name = "uuid"
+    version = "1.47.3"
 
     class Source(ReleaseDownload):
         archive = Remotefile(

--- a/kiwixbuild/dependencies/xapian.py
+++ b/kiwixbuild/dependencies/xapian.py
@@ -8,6 +8,7 @@ import platform
 
 class Xapian(Dependency):
     name = "xapian-core"
+    version = "1.4.26"
 
     if platform.system() == "Windows":
 

--- a/kiwixbuild/dependencies/zim_testing_suite.py
+++ b/kiwixbuild/dependencies/zim_testing_suite.py
@@ -5,6 +5,7 @@ from kiwixbuild.utils import Remotefile
 
 class ZimTestingSuite(Dependency):
     name = "zim-testing-suite"
+    version = "0.8.0"
     dont_skip = True
 
     class Source(ReleaseDownload):

--- a/kiwixbuild/dependencies/zlib.py
+++ b/kiwixbuild/dependencies/zlib.py
@@ -11,6 +11,7 @@ from kiwixbuild._global import neutralEnv
 
 class zlib(Dependency):
     name = "zlib"
+    version = "1.3.1"
 
     class Source(ReleaseDownload):
         src_archive = Remotefile(

--- a/kiwixbuild/dependencies/zstd.py
+++ b/kiwixbuild/dependencies/zstd.py
@@ -5,6 +5,7 @@ from kiwixbuild.utils import Remotefile
 
 class zstd(Dependency):
     name = "zstd"
+    version = "1.5.2"
 
     class Source(ReleaseDownload):
         archive = Remotefile(


### PR DESCRIPTION
Fixes #877

Moved all dependency versions from kiwixbuild/versions.py
into their respective Dependency classes as a `version` property,
as suggested in issue #866. This makes version management
more modular and easier to maintain.
