### PR TITLE
Add docstring to escape_path utility function

### DIFF
--- a/kiwixbuild/utils.py
+++ b/kiwixbuild/utils.py
@@ -47,6 +47,11 @@ regex_space = re.compile(r"((?<!\\) )")
 
 
 def escape_path(path):
+    """
+    Escape spaces in a filesystem path so it can be safely used in shell commands.
+
+    This replaces unescaped spaces with '\ ' while preserving existing escapes.
+    """
     path = str(path)
     return regex_space.sub(r"\ ", path)
 


### PR DESCRIPTION
This PR adds a short docstring to the escape_path helper function to clarify
its purpose and behavior when handling filesystem paths with spaces.

No functional or behavioral changes are introduced.