### PR TITLE
import buildenv explicitly in __init__.py to prevent dependency errors

### DIFF
--- a/kiwixbuild/__init__.py
+++ b/kiwixbuild/__init__.py
@@ -8,6 +8,7 @@ from .configs import ConfigInfo
 from .builder import Builder
 from .flatpak_builder import FlatpakBuilder
 from . import _global
+from . import buildenv
 
 
 def parse_args():


### PR DESCRIPTION
`kiwixbuild/__init__.py` uses `buildenv` but does not import it.

Currently, it works due to a side-effect where importing the `dependencies` package  loads `buildenv` and binds it to the kiwixbuild scope. If dependencies is refactored or import order changes, `__init__.py` crashes with a `NameError` and it's been confusing trying to figure out how this worked in the first place