### PR TITLE
Update actions checkout python

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
     - name: Setup python 3.13
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
     - name: Install packages
@@ -298,7 +298,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
     - name: Setup python 3.13
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
     - name: Install packages

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,7 @@ jobs:
       HOME: 'C:\\Users\\runneradmin'
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup python 3.13
       uses: actions/setup-python@v5
       with:
@@ -296,7 +296,7 @@ jobs:
       # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode
       run: sudo xcode-select -s /Applications/Xcode_16.1.app
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup python 3.13
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       HOME: 'C:\\Users\\runneradmin'
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup python 3.13
       uses: actions/setup-python@v5
       with:
@@ -292,7 +292,7 @@ jobs:
       # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode
       run: sudo xcode-select -s /Applications/Xcode_16.1.app
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Setup Python 3.13
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
     - name: Setup python 3.13
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
     - name: Install packages
@@ -294,7 +294,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v6
     - name: Setup Python 3.13
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.13'
     - name: Install packages


### PR DESCRIPTION
Update `actions/checkout` and `actions/setup-python` to `v6` to avoid using old Node.js 20.