### PR TITLE
Update release/nightly/ci uploads for new destination

### DIFF
--- a/.github/scripts/common.py
+++ b/.github/scripts/common.py
@@ -365,10 +365,10 @@ def upload_archive(archive, project, make_release, dev_branch=None):
         return
 
     if project.startswith("kiwix-") or project in ["libkiwix"]:
-        host = "ci@master.download.kiwix.org:30022"
+        host = "kiwix-build@master.download.kiwix.org:30322"
         dest_path = "/data/download/"
     else:
-        host = "ci@download.openzim.org:30022"
+        host = "kiwix-build@download.openzim.org:30322"
         dest_path = "/data/openzim/"
 
     if make_release:

--- a/.github/scripts/compile_all_deps.py
+++ b/.github/scripts/compile_all_deps.py
@@ -18,5 +18,5 @@ for target in select_build_targets(DEPS):
         destination = "/data/tmp/ci/dev_preview/" + DEV_BRANCH
     else:
         destination = "/data/tmp/ci"
-    upload(archive_file, "ci@tmp.kiwix.org:30022", destination)
+    upload(archive_file, "kiwix-build@tmp.kiwix.org:30522", destination)
     os.remove(str(archive_file))

--- a/.github/scripts/ensure_base_deps.py
+++ b/.github/scripts/ensure_base_deps.py
@@ -61,7 +61,7 @@ def main():
             print_message("Cannot get archive. Build dependencies")
             run_kiwix_build("alldependencies", config=COMPILE_CONFIG)
             archive_file = make_deps_archive(name=base_dep_archive_name, full=True)
-            upload(archive_file, "ci@tmp.kiwix.org:30022", "/data/tmp/ci")
+            upload(archive_file, "kiwix-build@tmp.kiwix.org:30522", "/data/tmp/ci")
             os.remove(str(archive_file))
 
 

--- a/.github/scripts/upload_failure_logs.py
+++ b/.github/scripts/upload_failure_logs.py
@@ -15,4 +15,4 @@ with tarfile.open(ARCHIVE_NAME, "w:xz") as tar:
     for name in set(files_to_archive):
         tar.add(str(name))
 
-upload(ARCHIVE_NAME, "ci@tmp.kiwix.org:30022", "/data/tmp/ci")
+upload(ARCHIVE_NAME, "kiwix-build@tmp.kiwix.org:30522", "/data/tmp/ci")

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,7 +52,7 @@ jobs:
     - name: secret
       shell: bash
       run: |
-        echo "${{secrets.KIWIX_FILE_UPLOAD_SSH_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
+        echo "${{secrets.KIWIXBUILD_FILE_UPLOAD_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
       env:
         KIWIX_FILE_UPLOAD_SSH_KEY_PATH: ${{ runner.temp }}/kiwix_file_upload_key
     - name: Install and configure eSigner CKA and Windows SDK
@@ -153,7 +153,7 @@ jobs:
     - name: secret
       shell: bash
       run: |
-        echo "${{secrets.KIWIX_FILE_UPLOAD_SSH_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
+        echo "${{secrets.KIWIXBUILD_FILE_UPLOAD_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
         chmod 600 $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
     - name: Ensure base deps
       shell: bash
@@ -204,7 +204,7 @@ jobs:
     - name: secret
       shell: bash
       run: |
-        echo "${{secrets.KIWIX_FILE_UPLOAD_SSH_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
+        echo "${{secrets.KIWIXBUILD_FILE_UPLOAD_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
         chmod 600 $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
     - name: Ensure base deps
       shell: bash
@@ -254,7 +254,7 @@ jobs:
     - name: secret
       shell: bash
       run: |
-        echo "${{secrets.KIWIX_FILE_UPLOAD_SSH_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
+        echo "${{secrets.KIWIXBUILD_FILE_UPLOAD_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
         chmod 600 $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
         echo "${{secrets.KIWIXBOT_GIT_SSH_KEY}}" > $KIWIXBOT_GIT_SSH_KEY_PATH
         chmod 600 $KIWIXBOT_GIT_SSH_KEY_PATH
@@ -311,7 +311,7 @@ jobs:
     - name: secret
       shell: bash
       run: |
-        echo "${{secrets.KIWIX_FILE_UPLOAD_SSH_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
+        echo "${{secrets.KIWIXBUILD_FILE_UPLOAD_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
         chmod 600 $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
     - name: install Apple certificate
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     - name: secret
       shell: bash
       run: |
-        echo "${{secrets.KIWIX_FILE_UPLOAD_SSH_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
+        echo "${{secrets.KIWIXBUILD_FILE_UPLOAD_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
       env:
         KIWIX_FILE_UPLOAD_SSH_KEY_PATH: ${{ runner.temp }}/kiwix_file_upload_key
     - name: Ensure base deps
@@ -134,7 +134,7 @@ jobs:
     - name: secret
       shell: bash
       run: |
-        echo "${{secrets.KIWIX_FILE_UPLOAD_SSH_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
+        echo "${{secrets.KIWIXBUILD_FILE_UPLOAD_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
         chmod 600 $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
     - name: Ensure base deps
       shell: bash
@@ -197,7 +197,7 @@ jobs:
     - name: secret
       shell: bash
       run: |
-        echo "${{secrets.KIWIX_FILE_UPLOAD_SSH_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
+        echo "${{secrets.KIWIXBUILD_FILE_UPLOAD_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
         chmod 600 $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
     - name: Ensure base deps
       shell: bash
@@ -254,7 +254,7 @@ jobs:
     - name: secret
       shell: bash
       run: |
-        echo "${{secrets.KIWIX_FILE_UPLOAD_SSH_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
+        echo "${{secrets.KIWIXBUILD_FILE_UPLOAD_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
         chmod 600 $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
     - name: Ensure base deps
       shell: bash
@@ -307,7 +307,7 @@ jobs:
     - name: secret
       shell: bash
       run: |
-        echo "${{secrets.KIWIX_FILE_UPLOAD_SSH_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
+        echo "${{secrets.KIWIXBUILD_FILE_UPLOAD_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
         chmod 600 $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
     - name: Ensure base deps
       shell: bash


### PR DESCRIPTION
As part of a server/infra change, the upload of nightly and release builds is done to a new destination.

tmp.kiwix.org/ci also changed destination

The receiving service now uses per-project (well per-repo) users with independent SSH Keys. Each users now only has access to the folders in which it is expected to upload files.

- Host remains the same: `master.download.kiwix.org` and `tmp.kiwix.org`
- Username changes from `ci` to `kiwix-build`
- Port changes from `30022` to `30322` and `30522` (tmp)
- Paths remains the same

⚠️ DO NOT MERGE ATM