### PR TITLE
Fix CI/CD after bringing libtorrent to kiwix-desktop

### DIFF
--- a/.github/scripts/build_definition.py
+++ b/.github/scripts/build_definition.py
@@ -39,7 +39,8 @@ BUILD_DEF = """
     | jammy     | flatpak            |        |          |           |             | BP            |                         |                        |
     | jammy     | native_static      | d      | d        | dBPSD     | dBPSD       |               | linux-x86_64            | linux-x86_64-static    |
     | jammy     | native_mixed       | BPS    | BPS      |           |             |               | linux-x86_64            |                        |
-    | jammy     | native_dyn         | d      | d        | dB        | dB          | dBPS          |                         | linux-x86_64-dyn       |
+    | jammy     | native_dyn         | d      | d        | dB        | dB          |               |                         | linux-x86_64-dyn       |
+    | noble     | native_dyn         |        |          |           |             | dBPS          |                         | linux-x86_64-dyn       |
     # libzim CI is building alpine_dyn but not us
     | jammy     | android_arm        | dBP    | dBP      |           |             |               | android-arm             | android-arm            |
     | jammy     | android_arm64      | dBP    | dBP      |           |             |               | android-arm64           | android-arm64          |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -137,7 +137,7 @@ jobs:
       KIWIX_FILE_UPLOAD_SSH_KEY_PATH: /tmp/kiwix_file_upload_key
     runs-on: ubuntu-22.04
     container:
-      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2025-11-05"
+      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2026-04-25"
       options: "--device /dev/fuse --privileged"
     steps:
     - name: Checkout code
@@ -188,7 +188,7 @@ jobs:
       KIWIX_FILE_UPLOAD_SSH_KEY_PATH: /tmp/kiwix_file_upload_key
     runs-on: ubuntu-22.04-arm
     container:
-      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2025-11-05"
+      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2026-04-25"
       options: "--device /dev/fuse --privileged"
     steps:
     - name: Checkout code

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -149,7 +149,12 @@ jobs:
         git clone https://github.com/${REP}
         cd ./${REP##*/}
         git checkout --force ${GITHUB_SHA}
-        pip3 install --user --no-deps .
+        pip3_extra_options=()
+        if pip3 install --help|grep -qF -- --break-system-packages
+        then
+          pip3_extra_options+=(--break-system-packages)
+        fi
+        pip3 install --user --no-deps "${pip3_extra_options[@]}" .
       env:
         REP: ${{github.repository}}
     - name: secret

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -130,6 +130,8 @@ jobs:
           - x86-64_musl_mixed
         image_variant: ['jammy']
         include:
+          - config: native_dyn
+            image_variant: noble
           - config: native_mixed
             image_variant: x86-64_manylinux
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,13 +126,23 @@ jobs:
         git clone https://github.com/${REP}
         cd ./${REP##*/}
         git checkout --force ${GITHUB_SHA}
-        pip3 install --user --no-deps .
+        pip3_extra_options=()
+        if pip3 install --help|grep -qF -- --break-system-packages
+        then
+          pip3_extra_options+=(--break-system-packages)
+        fi
+        pip3 install --user --no-deps "${pip3_extra_options[@]}" .
       env:
         REP: ${{github.repository}}
     - name: Install paramiko
-      if: ${{matrix.image_variant != 'bionic' }}
       shell: bash
-      run: pip3 install --user paramiko
+      run: |
+        pip3_extra_options=()
+        if pip3 install --help|grep -qF -- --break-system-packages
+        then
+          pip3_extra_options+=(--break-system-packages)
+        fi
+        pip3 install --user "${pip3_extra_options[@]}" paramiko
     - name: secret
       shell: bash
       run: |
@@ -193,7 +203,6 @@ jobs:
       env:
         REP: ${{github.repository}}
     - name: Install paramiko
-      if: ${{matrix.image_variant != 'bionic' }}
       shell: bash
       run: pip3 install --user paramiko
     - name: secret

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       OS_NAME: ${{matrix.image_variant}}
     runs-on: ubuntu-22.04
     container:
-      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2025-11-05"
+      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2026-04-25"
       options: "--device /dev/fuse --privileged"
     steps:
     - name: Checkout code
@@ -177,7 +177,7 @@ jobs:
       OS_NAME: ${{matrix.image_variant}}
     runs-on: ubuntu-22.04-arm
     container:
-      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2025-11-05"
+      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2026-04-25"
       options: "--device /dev/fuse --privileged"
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,10 @@ jobs:
           - x86-64_musl_mixed
         image_variant: ['jammy']
         include:
-        - config: native_mixed
-          image_variant: x86-64_manylinux
+          - config: native_dyn
+            image_variant: noble
+          - config: native_mixed
+            image_variant: x86-64_manylinux
     env:
       HOME: /home/runner
       KIWIX_FILE_UPLOAD_SSH_KEY_PATH: /tmp/kiwix_file_upload_key

--- a/kiwixbuild/flatpak_builder.py
+++ b/kiwixbuild/flatpak_builder.py
@@ -74,6 +74,54 @@ MANIFEST = {
 
 GET_REF_URL_API_TEMPLATE = "https://api.github.com/repos{repo}/git/refs/tags/{ref}"
 
+LIBTORRENT_MODULES = [
+    {
+        # Library installation directory (CMAKE_INSTALL_LIBDIR) for libtorrent
+        # is resolved by cmake to /app/lib64 in this flatpak build, whereas the
+        # rest of the libs go into /app/lib, resulting in a linker error when
+        # building kiwix-desktop. This hack makes /app/lib64 a symlink to
+        # /app/lib.
+        "name": "lib64hack",
+        "buildsystem": "simple",
+        "build-commands": [
+            "ln -s lib /app/lib64 ",
+        ],
+        "sources": [
+        ]
+    },
+
+    {
+        "name": "boost",
+        "buildsystem": "simple",
+        "build-commands": [
+            "./bootstrap.sh --prefix=/app --with-libraries=headers",
+            "./b2 install variant=release link=shared runtime-link=shared cxxflags=\"$CXXFLAGS\" linkflags=\"$LDFLAGS\" -j $FLATPAK_BUILDER_N_JOBS"
+        ],
+        "sources": [
+            {
+                "type": "archive",
+                "url": "https://archives.boost.io/release/1.90.0/source/boost_1_90_0.tar.bz2",
+                "sha256": "49551aff3b22cbc5c5a9ed3dbc92f0e23ea50a0f7325b0d198b705e8ee3fc305"
+            }
+        ]
+    },
+
+    {
+        "name": "libtorrent",
+        "buildsystem": "cmake-ninja",
+        "builddir": True,
+        "config-opts": [
+            "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+        ],
+        "sources": [
+            {
+                "type": "archive",
+                "url": "https://github.com/arvidn/libtorrent/releases/download/v2.0.7/libtorrent-rasterbar-2.0.7.tar.gz",
+                "sha256": "3850a27aacb79fcc4d352c1f02a7a59e0e8322afdaa1f5d58d676c02edfcfa36"
+            }
+        ]
+    }
+]
 
 class FlatpakBuilder:
     def __init__(self):
@@ -222,7 +270,7 @@ class FlatpakBuilder:
                             }
                          ]
         }
-        modules = [meson_module] + modules
+        modules = LIBTORRENT_MODULES + [meson_module] + modules
 
         for m in modules:
             temp = m["sources"]

--- a/scripts/create_kiwix-desktop_appImage.sh
+++ b/scripts/create_kiwix-desktop_appImage.sh
@@ -15,9 +15,9 @@ ICONFILE=$SOURCEDIR/resources/icons/kiwix/scalable/kiwix-desktop.svg
 DESKTOPFILE=$SOURCEDIR/resources/org.kiwix.desktop.desktop
 
 # Get linuxdeploy
-wget --continue https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20240109-1/linuxdeploy-x86_64.AppImage
+wget --continue https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20251107-1/linuxdeploy-x86_64.AppImage
 chmod u+x linuxdeploy-x86_64.AppImage
-wget --continue https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/1-alpha-20240109-1/linuxdeploy-plugin-qt-x86_64.AppImage
+wget --continue https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/1-alpha-20250213-1/linuxdeploy-plugin-qt-x86_64.AppImage
 chmod u+x linuxdeploy-plugin-qt-x86_64.AppImage
 
 # Fill with all deps libs and so
@@ -41,7 +41,7 @@ patchelf --set-rpath '$ORIGIN/../lib' $APPDIR/usr/libexec/QtWebEngineProcess
 
 mv $APPDIR/{AppRun.wrapped,kiwix-desktop}
 sed -i 's/AppRun\.wrapped/kiwix-desktop/g' $APPDIR/AppRun
-wget --continue https://github.com/AppImage/AppImageKit/releases/download/13/obsolete-appimagetool-x86_64.AppImage
-chmod u+x obsolete-appimagetool-x86_64.AppImage
+wget --continue https://github.com/AppImage/appimagetool/releases/download/1.9.1/appimagetool-x86_64.AppImage
+chmod u+x appimagetool-x86_64.AppImage
 
-./obsolete-appimagetool-x86_64.AppImage AppDir Kiwix-"$VERSION"-x86_64.AppImage
+./appimagetool-x86_64.AppImage AppDir Kiwix-"$VERSION"-x86_64.AppImage


### PR DESCRIPTION
Should fix kiwix/kiwix-desktop#1488

The biggest pitfall with this PR is that the builder for `kiwix-desktop` is upgraded from `jammy` to `noble`, the most undesirable consequence of it being that the `kiwix-desktop` appimages produced by our CI/CD will no longer run on `jammy`.