### PR TITLE
Use Ubuntu 26.04 (in place of 24.02) to build Kiwix Desktop

### DIFF
--- a/.github/scripts/build_definition.py
+++ b/.github/scripts/build_definition.py
@@ -40,7 +40,7 @@ BUILD_DEF = """
     | jammy     | native_static      | d      | d        | dBPSD     | dBPSD       |               | linux-x86_64            | linux-x86_64-static    |
     | jammy     | native_mixed       | BPS    | BPS      |           |             |               | linux-x86_64            |                        |
     | jammy     | native_dyn         | d      | d        | dB        | dB          |               |                         | linux-x86_64-dyn       |
-    | noble     | native_dyn         |        |          |           |             | dBPS          |                         | linux-x86_64-dyn       |
+    | resolute  | native_dyn         |        |          |           |             | dBPS          |                         | linux-x86_64-dyn       |
     # libzim CI is building alpine_dyn but not us
     | jammy     | android_arm        | dBP    | dBP      |           |             |               | android-arm             | android-arm            |
     | jammy     | android_arm64      | dBP    | dBP      |           |             |               | android-arm64           | android-arm64          |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -131,7 +131,7 @@ jobs:
         image_variant: ['jammy']
         include:
           - config: native_dyn
-            image_variant: noble
+            image_variant: resolute
           - config: native_mixed
             image_variant: x86-64_manylinux
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         image_variant: ['jammy']
         include:
           - config: native_dyn
-            image_variant: noble
+            image_variant: resolute
           - config: native_mixed
             image_variant: x86-64_manylinux
     env:


### PR DESCRIPTION
Fixes #925

Compile Kiwix Desktop on Ubuntu 26.04 in place of 24.02, to benefit of Qt6.6+ which is mandatory for a proper user experience with new maps ZIM files.