### PR TITLE
Recreated dependencies after upgrading the macOS build platform

### DIFF
--- a/kiwixbuild/dependencies/libmicrohttpd.py
+++ b/kiwixbuild/dependencies/libmicrohttpd.py
@@ -22,6 +22,7 @@ class MicroHttpd(Dependency):
             "libmicrohttpd_meson_pkgconfig.patch",
             "libmicrohttpd_meson_timeval_tvsec_size.patch",
             "libmicrohttpd_meson_winet6.patch",
+            "libmicrohttpd_meson_pipe2.patch",
         ]
 
     class Builder(MesonBuilder):

--- a/kiwixbuild/patches/libmicrohttpd_meson_pipe2.patch
+++ b/kiwixbuild/patches/libmicrohttpd_meson_pipe2.patch
@@ -1,0 +1,14 @@
+--- libmicrohttpd-0.9.76/meson.build.orig       2026-05-27 13:37:50
++++ libmicrohttpd-0.9.76/meson.build    2026-05-27 13:44:16
+@@ -152,7 +152,10 @@
+ )
+ cdata.set('SIZEOF_UINT64_T', 8)
+
+-cdata.set('HAVE_PIPE2_FUNC', cc.has_function('pipe2'))
++if host_machine.system() != 'darwin'
++  cdata.set('HAVE_PIPE2_FUNC', cc.has_function('pipe2'))
++endif
++
+ cdata.set('MHD_HAVE___BUILTIN_BSWAP32', cc.has_function('__builtin_bswap32'))
+ cdata.set('MHD_HAVE___BUILTIN_BSWAP64', cc.has_function('__builtin_bswap64'))
+

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -33,7 +33,7 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = "22"
+base_deps_meta_version = "23"
 
 base_deps_versions = {
     "zlib": "1.3.1",


### PR DESCRIPTION
Should fix #938

In #936, `base_deps_meta_version` should have been bumped so that dependencies are recreated using the new version of XCode. Then [the problem](https://github.com/kiwix/kiwix-build/issues/938) would have been caught by the PR CI.

This PR does that and fixes the problem with `libmicrohttpd` in the iOS Simulator cross-compilation via a hack (by suppressing the buggy check). 

The CI has been run twice:

1. https://github.com/kiwix/kiwix-build/actions/runs/26516984542 - this run re-created the dependency archives (and proceeded to building the other targets)
2. https://github.com/kiwix/kiwix-build/actions/runs/26520673790 - this run re-used the dependency archives created by the first run.