### PR TITLE
Expose dependency archive paths from dl_deps_archive action

### DIFF
--- a/actions/dl_deps_archive/README.md
+++ b/actions/dl_deps_archive/README.md
@@ -38,10 +38,37 @@ By default, the current branch on which the action is run.
 
 Where to extract the dependencies archive. By default it is `$HOME`
 
+## Outputs
+
+### `extract-dir`
+Directory where the archive was extracted.
+
+### `build-dir`
+Detected primary `BUILD_*` directory.
+
+### `install-dir`
+`INSTALL` directory inside the primary build directory.
+
+### `pkg-config-path`
+Path list suitable for `PKG_CONFIG_PATH`.
+
+### `ld-library-path`
+Path list suitable for `LD_LIBRARY_PATH`.
+
+### `cppflags`
+Include flags suitable for `CPPFLAGS`.
+
+### `meson-cross-file`
+Detected Meson cross file, if present.
+
+### `cmake-toolchain-file`
+Detected CMake toolchain file, if present.
+
 
 ## Example usage
 
 ```yaml
+id: deps
 uses: kiwix/kiwix-build/actions/dl_deps_archive@main
 with:
   target_platform: ${{ matrix.target_platform }}
@@ -52,4 +79,10 @@ uses: kiwix/kiwix-build/actions/dl_deps_archive@main
 with:
   target_platform: native_mixed
   os_name: windows
+```
+
+```yaml
+env:
+  PKG_CONFIG_PATH: ${{ steps.deps.outputs.pkg-config-path }}
+  CPPFLAGS: ${{ steps.deps.outputs.cppflags }}
 ```

--- a/actions/dl_deps_archive/action.yml
+++ b/actions/dl_deps_archive/action.yml
@@ -20,6 +20,23 @@ inputs:
   extract_dir:
     description: "Where to extract our dependencies. [Default to env var `HOME`]"
     required: false
+outputs:
+  extract-dir:
+    description: "Directory where the archive was extracted"
+  build-dir:
+    description: "Detected primary BUILD_* directory"
+  install-dir:
+    description: "INSTALL directory inside the primary build directory"
+  pkg-config-path:
+    description: "Path list for PKG_CONFIG_PATH"
+  ld-library-path:
+    description: "Path list for LD_LIBRARY_PATH"
+  cppflags:
+    description: "Include flags for CPPFLAGS"
+  meson-cross-file:
+    description: "Detected Meson cross file, if present"
+  cmake-toolchain-file:
+    description: "Detected CMake toolchain file, if present"
 runs:
   using: 'node20'
   main: 'dist/index.js'

--- a/actions/dl_deps_archive/dist/index.js
+++ b/actions/dl_deps_archive/dist/index.js
@@ -30468,6 +30468,7 @@ const tc = __nccwpck_require__(8635);
 const core = __nccwpck_require__(2619);
 const path = __nccwpck_require__(1017);
 const os = __nccwpck_require__(2037);
+const fs = __nccwpck_require__(7147);
 
 function getInput(name, dflt) {
   const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`];
@@ -30479,6 +30480,81 @@ function getInput(name, dflt) {
 
 function addLocalPath(inputPath) {
   process.env["PATH"] = `${inputPath}${path.delimiter}${process.env["PATH"]}`;
+}
+
+function exists(inputPath) {
+  return inputPath && fs.existsSync(inputPath);
+}
+
+function unique(items) {
+  return [...new Set(items.filter(exists))];
+}
+
+function listBuildDirs(root) {
+  if (!exists(root)) {
+    return [];
+  }
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith("BUILD_"))
+    .map((entry) => path.join(root, entry.name))
+    .filter((buildDir) => exists(path.join(buildDir, "INSTALL")))
+    .sort((a, b) => {
+      if (path.basename(a) === "BUILD_neutral") return 1;
+      if (path.basename(b) === "BUILD_neutral") return -1;
+      return a.localeCompare(b);
+    });
+}
+
+function findLibDirs(installDir) {
+  const dirs = [path.join(installDir, "lib"), path.join(installDir, "lib64")];
+  const libDir = path.join(installDir, "lib");
+  if (exists(libDir)) {
+    for (const entry of fs.readdirSync(libDir, { withFileTypes: true })) {
+      if (entry.isDirectory() && entry.name !== "pkgconfig") {
+        dirs.push(path.join(libDir, entry.name));
+      }
+    }
+  }
+  return unique(dirs);
+}
+
+function findPkgConfigDirs(installDir) {
+  return unique(findLibDirs(installDir).map((dir) => path.join(dir, "pkgconfig")));
+}
+
+function findFirstFile(buildDirs, fileName) {
+  for (const buildDir of buildDirs) {
+    const filePath = path.join(buildDir, fileName);
+    if (exists(filePath)) {
+      return filePath;
+    }
+  }
+  return "";
+}
+
+function setArchiveOutputs(extractDir, archiveDir) {
+  const roots = unique([archiveDir, extractDir]);
+  const buildDirs = unique(roots.flatMap(listBuildDirs));
+  const mesonCrossFile = findFirstFile(buildDirs, "meson_cross_file.txt");
+  const cmakeToolchainFile = findFirstFile(buildDirs, "cmake_cross_file.txt");
+  const buildDir = mesonCrossFile
+    ? path.dirname(mesonCrossFile)
+    : cmakeToolchainFile
+      ? path.dirname(cmakeToolchainFile)
+      : buildDirs[0] || "";
+  const installDir = buildDir ? path.join(buildDir, "INSTALL") : "";
+  const installDirs = buildDirs.map((dir) => path.join(dir, "INSTALL"));
+  const includeDirs = unique(installDirs.map((dir) => path.join(dir, "include")));
+
+  core.setOutput("extract-dir", archiveDir || extractDir);
+  core.setOutput("build-dir", buildDir);
+  core.setOutput("install-dir", exists(installDir) ? installDir : "");
+  core.setOutput("pkg-config-path", unique(installDirs.flatMap(findPkgConfigDirs)).join(path.delimiter));
+  core.setOutput("ld-library-path", unique(installDirs.flatMap(findLibDirs)).join(path.delimiter));
+  core.setOutput("cppflags", includeDirs.map((dir) => `-I${dir}`).join(" "));
+  core.setOutput("meson-cross-file", mesonCrossFile);
+  core.setOutput("cmake-toolchain-file", cmakeToolchainFile);
 }
 
 async function run() {
@@ -30509,9 +30585,10 @@ async function run() {
       archivePath = await tc.downloadTool(archive_url);
     }
 
-    process.stdout.write("Extracting " + archivePath + " to " + extract_dir);
+    process.stdout.write("Extracting " + archivePath + " to " + extract_dir + "\n");
     const archive_dir = await tc.extractTar(archivePath, extract_dir);
-    process.stdout.write("Extracted to " + archive_dir);
+    process.stdout.write("Extracted to " + archive_dir + "\n");
+    setArchiveOutputs(extract_dir, archive_dir);
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/actions/dl_deps_archive/dist/index.js
+++ b/actions/dl_deps_archive/dist/index.js
@@ -30533,9 +30533,12 @@ function findFirstFile(buildDirs, fileName) {
   return "";
 }
 
-function setArchiveOutputs(extractDir, archiveDir) {
+function setArchiveOutputs(extractDir, archiveDir, ignoredBuildDirs = []) {
   const roots = unique([archiveDir, extractDir]);
-  const buildDirs = unique(roots.flatMap(listBuildDirs));
+  const ignored = new Set(ignoredBuildDirs);
+  const buildDirs = unique(roots.flatMap(listBuildDirs)).filter(
+    (buildDir) => !ignored.has(buildDir),
+  );
   const mesonCrossFile = findFirstFile(buildDirs, "meson_cross_file.txt");
   const cmakeToolchainFile = findFirstFile(buildDirs, "cmake_cross_file.txt");
   const buildDir = mesonCrossFile
@@ -30573,6 +30576,7 @@ async function run() {
       "extract_dir",
       process.env["HOME"] || process.env["GITHUB_WORKSPACE"],
     );
+    const preExistingBuildDirs = listBuildDirs(extract_dir);
 
     let archivePath;
     try {
@@ -30588,7 +30592,7 @@ async function run() {
     process.stdout.write("Extracting " + archivePath + " to " + extract_dir + "\n");
     const archive_dir = await tc.extractTar(archivePath, extract_dir);
     process.stdout.write("Extracted to " + archive_dir + "\n");
-    setArchiveOutputs(extract_dir, archive_dir);
+    setArchiveOutputs(extract_dir, archive_dir, preExistingBuildDirs);
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/actions/dl_deps_archive/index.js
+++ b/actions/dl_deps_archive/index.js
@@ -67,9 +67,12 @@ function findFirstFile(buildDirs, fileName) {
   return "";
 }
 
-function setArchiveOutputs(extractDir, archiveDir) {
+function setArchiveOutputs(extractDir, archiveDir, ignoredBuildDirs = []) {
   const roots = unique([archiveDir, extractDir]);
-  const buildDirs = unique(roots.flatMap(listBuildDirs));
+  const ignored = new Set(ignoredBuildDirs);
+  const buildDirs = unique(roots.flatMap(listBuildDirs)).filter(
+    (buildDir) => !ignored.has(buildDir),
+  );
   const mesonCrossFile = findFirstFile(buildDirs, "meson_cross_file.txt");
   const cmakeToolchainFile = findFirstFile(buildDirs, "cmake_cross_file.txt");
   const buildDir = mesonCrossFile
@@ -107,6 +110,7 @@ async function run() {
       "extract_dir",
       process.env["HOME"] || process.env["GITHUB_WORKSPACE"],
     );
+    const preExistingBuildDirs = listBuildDirs(extract_dir);
 
     let archivePath;
     try {
@@ -122,7 +126,7 @@ async function run() {
     process.stdout.write("Extracting " + archivePath + " to " + extract_dir + "\n");
     const archive_dir = await tc.extractTar(archivePath, extract_dir);
     process.stdout.write("Extracted to " + archive_dir + "\n");
-    setArchiveOutputs(extract_dir, archive_dir);
+    setArchiveOutputs(extract_dir, archive_dir, preExistingBuildDirs);
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/actions/dl_deps_archive/index.js
+++ b/actions/dl_deps_archive/index.js
@@ -2,6 +2,7 @@ const tc = require("@actions/tool-cache");
 const core = require("@actions/core");
 const path = require("path");
 const os = require("os");
+const fs = require("fs");
 
 function getInput(name, dflt) {
   const val = process.env[`INPUT_${name.replace(/ /g, "_").toUpperCase()}`];
@@ -13,6 +14,81 @@ function getInput(name, dflt) {
 
 function addLocalPath(inputPath) {
   process.env["PATH"] = `${inputPath}${path.delimiter}${process.env["PATH"]}`;
+}
+
+function exists(inputPath) {
+  return inputPath && fs.existsSync(inputPath);
+}
+
+function unique(items) {
+  return [...new Set(items.filter(exists))];
+}
+
+function listBuildDirs(root) {
+  if (!exists(root)) {
+    return [];
+  }
+  return fs
+    .readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith("BUILD_"))
+    .map((entry) => path.join(root, entry.name))
+    .filter((buildDir) => exists(path.join(buildDir, "INSTALL")))
+    .sort((a, b) => {
+      if (path.basename(a) === "BUILD_neutral") return 1;
+      if (path.basename(b) === "BUILD_neutral") return -1;
+      return a.localeCompare(b);
+    });
+}
+
+function findLibDirs(installDir) {
+  const dirs = [path.join(installDir, "lib"), path.join(installDir, "lib64")];
+  const libDir = path.join(installDir, "lib");
+  if (exists(libDir)) {
+    for (const entry of fs.readdirSync(libDir, { withFileTypes: true })) {
+      if (entry.isDirectory() && entry.name !== "pkgconfig") {
+        dirs.push(path.join(libDir, entry.name));
+      }
+    }
+  }
+  return unique(dirs);
+}
+
+function findPkgConfigDirs(installDir) {
+  return unique(findLibDirs(installDir).map((dir) => path.join(dir, "pkgconfig")));
+}
+
+function findFirstFile(buildDirs, fileName) {
+  for (const buildDir of buildDirs) {
+    const filePath = path.join(buildDir, fileName);
+    if (exists(filePath)) {
+      return filePath;
+    }
+  }
+  return "";
+}
+
+function setArchiveOutputs(extractDir, archiveDir) {
+  const roots = unique([archiveDir, extractDir]);
+  const buildDirs = unique(roots.flatMap(listBuildDirs));
+  const mesonCrossFile = findFirstFile(buildDirs, "meson_cross_file.txt");
+  const cmakeToolchainFile = findFirstFile(buildDirs, "cmake_cross_file.txt");
+  const buildDir = mesonCrossFile
+    ? path.dirname(mesonCrossFile)
+    : cmakeToolchainFile
+      ? path.dirname(cmakeToolchainFile)
+      : buildDirs[0] || "";
+  const installDir = buildDir ? path.join(buildDir, "INSTALL") : "";
+  const installDirs = buildDirs.map((dir) => path.join(dir, "INSTALL"));
+  const includeDirs = unique(installDirs.map((dir) => path.join(dir, "include")));
+
+  core.setOutput("extract-dir", archiveDir || extractDir);
+  core.setOutput("build-dir", buildDir);
+  core.setOutput("install-dir", exists(installDir) ? installDir : "");
+  core.setOutput("pkg-config-path", unique(installDirs.flatMap(findPkgConfigDirs)).join(path.delimiter));
+  core.setOutput("ld-library-path", unique(installDirs.flatMap(findLibDirs)).join(path.delimiter));
+  core.setOutput("cppflags", includeDirs.map((dir) => `-I${dir}`).join(" "));
+  core.setOutput("meson-cross-file", mesonCrossFile);
+  core.setOutput("cmake-toolchain-file", cmakeToolchainFile);
 }
 
 async function run() {
@@ -43,9 +119,10 @@ async function run() {
       archivePath = await tc.downloadTool(archive_url);
     }
 
-    process.stdout.write("Extracting " + archivePath + " to " + extract_dir);
+    process.stdout.write("Extracting " + archivePath + " to " + extract_dir + "\n");
     const archive_dir = await tc.extractTar(archivePath, extract_dir);
-    process.stdout.write("Extracted to " + archive_dir);
+    process.stdout.write("Extracted to " + archive_dir + "\n");
+    setArchiveOutputs(extract_dir, archive_dir);
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
## Summary
- Add outputs to `actions/dl_deps_archive` for commonly needed paths after extraction.
- Detect the primary `BUILD_*` directory, `INSTALL` directory, pkg-config paths, library paths, include flags, and Meson/CMake cross files.
- Document the new outputs in the action README.

This does not directly fix a tracked issue that I found, but it should make downstream Kiwix CI workflows easier to simplify by avoiding hardcoded `BUILD_*` paths and repeated `PKG_CONFIG_PATH` / `CPPFLAGS` setup.

## Testing
- `node --check actions/dl_deps_archive/index.js`
- `node --check actions/dl_deps_archive/dist/index.js`
- Local smoke test with a fake dependency archive served over localhost, verifying download fallback, extraction, and generated GitHub action outputs.