### PR TITLE
Building libzim without writer on android and wasm

### DIFF
--- a/kiwixbuild/dependencies/libzim.py
+++ b/kiwixbuild/dependencies/libzim.py
@@ -32,6 +32,8 @@ class Libzim(Dependency):
         @property
         def configure_options(self):
             configInfo = self.buildEnv.configInfo
+            if configInfo.build in ("android", "wasm"):
+                yield "-Dwithout_writer=true"
             if neutralEnv("distname") == "Windows":
                 yield "-Dwerror=false"
             if configInfo.build == "android":


### PR DESCRIPTION
Fixes part of #946

Doing the same for iOS is somewhat problematic because of #948