### PR TITLE
aqtinstall-based builds of kiwix-desktop on jammy

### DIFF
--- a/.github/scripts/build_definition.py
+++ b/.github/scripts/build_definition.py
@@ -39,8 +39,7 @@ BUILD_DEF = """
     | jammy     | flatpak            |        |          |           |             | BP            |                         |                        |
     | jammy     | native_static      | d      | d        | dBPSD     | dBPSD       |               | linux-x86_64            | linux-x86_64-static    |
     | jammy     | native_mixed       | BPS    | BPS      |           |             |               | linux-x86_64            |                        |
-    | jammy     | native_dyn         | d      | d        | dB        | dB          |               |                         | linux-x86_64-dyn       |
-    | resolute  | native_dyn         |        |          |           |             | dBPS          |                         | linux-x86_64-dyn       |
+    | jammy     | native_dyn         | d      | d        | dB        | dB          | dBPS          |                         | linux-x86_64-dyn       |
     # libzim CI is building alpine_dyn but not us
     | jammy     | android_arm        | dBP    | dBP      |           |             |               | android-arm             | android-arm            |
     | jammy     | android_arm64      | dBP    | dBP      |           |             |               | android-arm64           | android-arm64          |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -132,8 +132,6 @@ jobs:
           - x86-64_musl_mixed
         image_variant: ['jammy']
         include:
-          - config: native_dyn
-            image_variant: resolute
           - config: native_mixed
             image_variant: x86-64_manylinux
     env:
@@ -141,7 +139,7 @@ jobs:
       KIWIX_FILE_UPLOAD_SSH_KEY_PATH: /tmp/kiwix_file_upload_key
     runs-on: ubuntu-22.04
     container:
-      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2026-04-25"
+      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2026-07-22"
       options: "--device /dev/fuse --privileged"
     steps:
     - name: Checkout code
@@ -164,6 +162,19 @@ jobs:
       run: |
         echo "${{secrets.KIWIXBUILD_FILE_UPLOAD_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
         chmod 600 $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
+    - name: Install QT
+      if: ${{ matrix.config == 'native_dyn' }}
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: 6.8.3
+        host: "linux"
+        target: "desktop"
+        dir: /home/runner
+        modules: "qtwebengine qtwebchannel qtpositioning qtserialport"
+        install-deps: false
+        setup-python: false
+      env:
+        AQT_CONFIG: ${{ github.workspace }}/.github/configs/aqt.ini
     - name: Ensure base deps
       shell: bash
       run: |
@@ -175,6 +186,7 @@ jobs:
       shell: bash
       run: |
         cd $HOME
+        PATH=/home/runner/Qt/6.8.3/gcc_64/bin:$PATH
         kiwix-build/.github/scripts/build_release_nightly.py
       env:
         COMPILE_CONFIG: ${{matrix.config}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,6 @@ jobs:
           - x86-64_musl_mixed
         image_variant: ['jammy']
         include:
-          - config: native_dyn
-            image_variant: resolute
           - config: native_mixed
             image_variant: x86-64_manylinux
     env:
@@ -116,7 +114,7 @@ jobs:
       OS_NAME: ${{matrix.image_variant}}
     runs-on: ubuntu-22.04
     container:
-      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2026-04-25"
+      image: "ghcr.io/kiwix/kiwix-build_ci_${{matrix.image_variant}}:2026-07-22"
       options: "--device /dev/fuse --privileged"
     steps:
     - name: Checkout code
@@ -148,6 +146,19 @@ jobs:
       run: |
         echo "${{secrets.KIWIXBUILD_FILE_UPLOAD_KEY}}" > $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
         chmod 600 $KIWIX_FILE_UPLOAD_SSH_KEY_PATH
+    - name: Install QT
+      if: ${{ matrix.config == 'native_dyn' }}
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: 6.8.3
+        host: "linux"
+        target: "desktop"
+        dir: /home/runner
+        modules: "qtwebengine qtwebchannel qtpositioning qtserialport"
+        install-deps: false
+        setup-python: false
+      env:
+        AQT_CONFIG: ${{ github.workspace }}/.github/configs/aqt.ini
     - name: Ensure base deps
       shell: bash
       run: |
@@ -166,6 +177,7 @@ jobs:
       shell: bash
       run: |
         cd $HOME
+        PATH=/home/runner/Qt/6.8.3/gcc_64/bin:$PATH
         kiwix-build/.github/scripts/build_projects.py
       env:
         COMPILE_CONFIG: ${{matrix.config}}

--- a/scripts/create_kiwix-desktop_appImage.sh
+++ b/scripts/create_kiwix-desktop_appImage.sh
@@ -5,6 +5,7 @@ set -e
 INSTALLDIR=${1:-$PWD/BUILD_native_dyn/INSTALL}
 SOURCEDIR=${2:-$PWD/SOURCE/kiwix-desktop}
 APPDIR=${3:-$PWD/AppDir}
+QTDIR=${4:-$PWD/Qt/6.8.3/gcc_64}
 
 SYSTEMLIBDIR=lib/x86_64-linux-gnu
 if [ ! -e "$INSTALLDIR/lib" ] ; then
@@ -35,6 +36,9 @@ mkdir -p $APPDIR/usr/bin/ && unzip aria2-1.37.0-x86_64-linux-musl_libressl_stati
 
 # Copy the CA trustore from the hosting system
 mkdir -p $APPDIR/etc/ssl/certs/ && cp /etc/ssl/certs/ca-certificates.crt $APPDIR/etc/ssl/certs/
+
+# Copy a Qt6 resource missed by linuxdeploy-plugin-qt
+cp "$QTDIR"/resources/v8_context_snapshot.bin "$APPDIR"/usr/resources/
 
 # Fix the RPATH of QtWebEngineProcess [TODO] Fill a issue ?
 patchelf --set-rpath '$ORIGIN/../lib' $APPDIR/usr/libexec/QtWebEngineProcess


### PR DESCRIPTION
Depends on kiwix/container-images#300
Should fix kiwix/kiwix-build#925

This PR makes CI and CD workflows build kiwix-desktop on jammy using Qt version 6.8.3 obtained via aqtinstall.