### PR TITLE
Disable ssl for libcurl in i586_* jobs

### DIFF
--- a/kiwixbuild/dependencies/libcurl.py
+++ b/kiwixbuild/dependencies/libcurl.py
@@ -29,9 +29,9 @@ class LibCurl(Dependency):
 
     class Builder(MesonBuilder):
         dependencies = ["zlib"]
-        configure_options = [
-            f"-D{p}=disabled"
-            for p in (
+
+        def get_features_to_disable(self):
+            yield from (
                 "psl",
                 "kerberos-auth",
                 "gss-api",
@@ -55,7 +55,16 @@ class LibCurl(Dependency):
                 "gopher",
                 "tool",
             )
-        ]
+
+            if self.buildEnv.configInfo.name in ("i586_static", "i586_dyn"):
+                yield "ssl"
+
+        @property
+        def configure_options(self):
+            return tuple(
+                f"-D{p}=disabled"
+                for p in self.get_features_to_disable()
+            )
 
         def _test(self, context):
             context.skip("No Test")


### PR DESCRIPTION
In the [current kiwix-build CI builder image](https://ghcr.io/kiwix/kiwix-build_ci_jammy:2026-07-22) OpenSSL (`libssl-dev`) is installed unintentionally as a dependency of `libtorrent-rasterbar-dev`. `libcurl`'s configuration step picks up that library which works fine on `x86_64` but fails for 32-bit cross compilations ([i586_static](https://github.com/kiwix/kiwix-build/actions/runs/30810074123/job/91684595659), [i586_dyn](https://github.com/kiwix/kiwix-build/actions/runs/30810074123/job/91684595617)) since only `libssl-dev:amd64` but not `libssl-dev:i386` is available.

A workaround for that problem avoiding the need to update the builder image is to build `libcurl` for 32-bit linux platforms without OpenSSL (just like it worked on the previous versions of the CI builder where OpenSSL was not available).