### PR TITLE
Re-enabled optimization for the compilation of Xapian

### DIFF
--- a/kiwixbuild/dependencies/xapian.py
+++ b/kiwixbuild/dependencies/xapian.py
@@ -44,7 +44,7 @@ class Xapian(Dependency):
             ]
             configure_env = {
                 "_format_LDFLAGS": "{env.LDFLAGS} -L{buildEnv.install_dir}/{buildEnv.libprefix}",
-                "_format_CXXFLAGS": "{env.CXXFLAGS} -I{buildEnv.install_dir}/include",
+                "_format_CXXFLAGS": "{env.CXXFLAGS} -O3 -I{buildEnv.install_dir}/include",
             }
 
             @classmethod

--- a/kiwixbuild/versions.py
+++ b/kiwixbuild/versions.py
@@ -33,7 +33,7 @@ release_versions = {
 
 # This is the "version" of the whole base_deps_versions dict.
 # Change this when you change base_deps_versions.
-base_deps_meta_version = "26"
+base_deps_meta_version = "27"
 
 base_deps_versions = {
     "zlib": "1.3.1",


### PR DESCRIPTION
Should fix openzim/libzim#1130

Optimized build of the Xapian dependency was lost by the following pair of commits:

1. f9b890c58df1ff5aeb4f9e6d568809c53415a346 (switch to meson builder)
2. 752bdd18acf0d7177dc1084effa01fc1147f6b26 (switch back to make builder but with the -O3 compiler flag lost).

~Note that in this PR `base_deps_meta_version` is not bumped. Thus CIs of respective kiwix projects will continue to use the unoptimized build of the xapian dependency (until `base_deps_meta_version` is increased for a better reason). Artefacts of any releases made in the interim will still include optimized version of xapian since dependencies are built independently during releases.~

`base_deps_meta_version` was bumped to have the xapian dependency rebuilt in CI thus ensuring against any surprises during release.